### PR TITLE
refactor: Return problems as key-value mapped objects

### DIFF
--- a/src/dataModelUtils/getFilteredProblems.js
+++ b/src/dataModelUtils/getFilteredProblems.js
@@ -1,3 +1,5 @@
+const { convert2DArrayToObjects } = require("../utils/convert2DArrayToObjects");
+
 function getFilteredProblems() {
     const excludeColumns = ['Subdominant Topic', 'Notes'];
     const problems = getSheetData('Problems', excludeColumns);
@@ -12,9 +14,11 @@ function getFilteredProblems() {
         'Input Data Structure': selectedInputDataStructure
     }
 
-    return filter2DArrayRows(problems, criteria);
+    const [problemHeaders, ...problemData] = filter2DArrayRows(problems, criteria);
+
+    return convert2DArrayToObjects(problemHeaders, problemData);
 }
 
 function getFilteredProblemsLogTest() {
-    Logger.log(getFilteredProblems());
+    getFilteredProblems().forEach(row => Logger.log(row));
 }


### PR DESCRIPTION
### Summary
Refactored the `getFilteredProblems` function to convert its filtered 2D array result into an array of objects, using the first row as headers and the remaining rows as data. This improves downstream data handling by enabling attribute-based access instead of index-based access.

### Changes
- Imported `convert2DArrayToObjects` utility
- Destructured the result of `filter2DArrayRows` into `problemHeaders` and `problemData`
- Converted the filtered problem set into an array of objects before returning
- Updated `getFilteredProblemsLogTest` to log the new object-based structure

### Problem Solved
This refactor makes it easier to:
- Join problem data with latest attempt records based on shared attributes  
- Access problem attributes directly by property name, improving readability and reducing reliance on column order assumptions  

### Testing
- Verified `getFilteredProblems()` logs expected array of objects in `getFilteredProblemsLogTest()`
- Confirmed attribute-based access works as intended in downstream use cases