### PR TITLE
feat: Get latest attempts per problem

### DIFF
--- a/src/dataModelUtils/getLatestAttemptsMap.js
+++ b/src/dataModelUtils/getLatestAttemptsMap.js
@@ -1,0 +1,11 @@
+function getLatestAttemptsMap() {
+    const excludeColumns = ['Notes'];
+    const attempts = getSheetData('Attempts', excludeColumns);
+
+    return mapLatestAttemptsByLcId(attempts);
+}
+
+function getLatestAttemptsMapLogTest() {
+    const attemptsObj = getLatestAttemptsMap();
+    Object.entries(attemptsObj).slice(0, 5).forEach(row => Logger.log(row));
+}

--- a/src/dataModelUtils/mapLatestAttemptsByLcId.js
+++ b/src/dataModelUtils/mapLatestAttemptsByLcId.js
@@ -1,0 +1,23 @@
+function mapLatestAttemptsByLcId(attempts) {
+    const [headers, ...data] = attempts;
+    const lcIdIndex = headers.indexOf('LC ID');
+    const startTimeIndex = headers.indexOf('Start Time');
+
+    if (lcIdIndex === -1 || startTimeIndex === -1) {
+        throw new Error('One or more required columns are missing from attempts data.');
+    }
+
+    const latestAttemptsMap = {};
+
+    for (const row of data) {
+        const lcId = row[lcIdIndex];
+        const startTime = new Date(row[startTimeIndex]);
+        if (!latestAttemptsMap[lcId] || new Date(latestAttemptsMap[lcId][startTimeIndex]) < startTime) {
+            latestAttemptsMap[lcId] = row;
+        }
+    }
+    
+    return latestAttemptsMap;
+}
+
+module.exports = { mapLatestAttemptsByLcId }

--- a/tests/dataModelUtils/mapLatestAttemptsByLcId.test.js
+++ b/tests/dataModelUtils/mapLatestAttemptsByLcId.test.js
@@ -1,0 +1,46 @@
+const { mapLatestAttemptsByLcId } = require("../../src/dataModelUtils/mapLatestAttemptsByLcId");
+
+describe('mapLatestAttemptsByLcId', () => {
+    it('Returns latest attempt for each problem', () => {
+        const attempts = [
+            ['LC ID', 'Start Time', 'Notes'],
+            [1, 'Sun Apr 20 09:23:32 GMT-07:00 2025', 'First Try'],
+            [1, 'Mon Apr 28 09:23:32 GMT-07:00 2025', 'Second Try'],
+            [2, 'Mon Apr 21 09:23:32 GMT-07:00 2025', 'First Try'],
+            [2, 'Mon Apr 28 09:23:32 GMT-07:00 2025', 'Second Try'],
+            [3, 'Tue Apr 29 09:23:32 GMT-07:00 2025', 'Second Try'],
+            [3, 'Mon Apr 21 09:23:32 GMT-07:00 2025', 'First Try'],
+        ]
+
+        const result = mapLatestAttemptsByLcId(attempts);
+
+        expect(Object.keys(result).length).toBe(3);
+        expect(result['1'][1]).toBe('Mon Apr 28 09:23:32 GMT-07:00 2025');
+        expect(result['2'][1]).toBe('Mon Apr 28 09:23:32 GMT-07:00 2025');
+        expect(result['3'][1]).toBe('Tue Apr 29 09:23:32 GMT-07:00 2025');
+    });
+
+    it('Returns empty object when given only headers and no data rows', () => {
+        const attempts = [
+            ['LC ID', 'Start Time',]
+        ]
+        const result = mapLatestAttemptsByLcId(attempts);
+        expect(result).toEqual({});
+    });
+
+    it('Throws error if "LC ID" column is missing', () => {
+        const attempts = [
+            ['Start Time'],
+            ['Sun Apr 20 09:23:32 GMT-07:00 2025']
+        ]
+        expect(() => mapLatestAttemptsByLcId(attempts).toThrow('One or more required columns are missing from attempts data.'));
+    });
+
+    it('Throws error if "Start Time" column is missing', () => {
+        const attempts = [
+            ['LC ID'],
+            [1]
+        ]
+        expect(() => mapLatestAttemptsByLcId(attempts).toThrow('One or more required columns are missing from attempts data.'));
+    });
+});


### PR DESCRIPTION
## 📦 Summary

Adds utility functions to retrieve and map the latest attempt for each problem based on `LC ID` and `Start Time` from the Attempts sheet data. Also includes corresponding unit tests to validate expected behavior and edge cases.

---

## 🔧 Changes

- **Added** `getLatestAttemptsMap` function in `src/dataModelUtils/getLatestAttemptsMap.js`
  - Fetches Attempts sheet data (excluding `Notes`) and maps latest attempts by `LC ID`.
  - Includes a log test helper `getLatestAttemptsMapLogTest` for manual inspection.

- **Added** `mapLatestAttemptsByLcId` utility in `src/dataModelUtils/mapLatestAttemptsByLcId.js`
  - Maps the latest attempt per `LC ID` by comparing `Start Time`.
  - Throws an error if required columns are missing.
  - Exported via `module.exports`.

- **Added** `mapLatestAttemptsByLcId.test.js` test suite in `tests/dataModelUtils/`
  - ✅ Verifies correct mapping of latest attempts for each problem.
  - ✅ Tests handling of no data rows.
  - ✅ Confirms errors are thrown if required columns (`LC ID`, `Start Time`) are missing.

---

## 📝 Notes

This sets up the groundwork for reliably pulling the most recent attempt per problem for future picker and logger logic.

Closes #22 