### PR TITLE
feat: Add End Workflow Handler and Utility for Setting Named Range Values

### DIFF
--- a/src/endWorkflow.js
+++ b/src/endWorkflow.js
@@ -1,0 +1,16 @@
+const { isAttemptDone, isAttemptInProgress } = require("./workflowUtils");
+const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
+
+function onEndClick() {
+    if (!isAttemptInProgress()) {
+        SpreadsheetApp.getUi().alert('No attempt currently in progress.');
+        return;
+    }
+
+    if (isAttemptDone()) {
+        SpreadsheetApp.getUi().alert('An attempt has already been marked done and needs to be logged.');
+        return;
+    }
+
+    setNamedRangeValue('ControlPanel_EndTime', new Date());
+}

--- a/src/sheetUtils/getNamedRange.js
+++ b/src/sheetUtils/getNamedRange.js
@@ -13,3 +13,5 @@ function getNamedRange(rangeName) {
     
     return range;
 }
+
+module.exports = { getNamedRange }

--- a/src/sheetUtils/getNamedRangeValue.js
+++ b/src/sheetUtils/getNamedRangeValue.js
@@ -1,3 +1,5 @@
+const { getNamedRange } = require("./getNamedRange");
+
 /**
  * Retrieves the value of a named range from the active spreadsheet.
  *
@@ -5,14 +7,9 @@
  *
  * @param {string} name - The name of the named range to retrieve.
  * @returns {*} The value of the named range.
- * @throws {Error} If the named range does not exist.
  */
 function getNamedRangeValue(name) {
-    const range = SpreadsheetApp.getActiveSpreadsheet().getRangeByName(name);
-    if (!range) {
-        throw new Error(`Named range "${name}" does not exist.`);
-    }
-    return range.getValue();
+    return getNamedRange(name).getValue();
 }
 
 module.exports = { getNamedRangeValue }

--- a/src/sheetUtils/setNamedRangeValue.js
+++ b/src/sheetUtils/setNamedRangeValue.js
@@ -1,0 +1,13 @@
+const { getNamedRange } = require("./getNamedRange");
+
+/**
+ * Sets the value of a named range in the active Google Sheets spreadsheet.
+ *
+ * @param {string} name - The name of the named range to update.
+ * @param {*} value - The value to set for the named range.
+ */
+function setNamedRangeValue(name, value) {
+    getNamedRange(name).setValue(value);
+}
+
+module.exports = { setNamedRangeValue }


### PR DESCRIPTION
### Summary  
This PR introduces the `onEndClick` workflow function to handle end-of-attempt actions within the Google Sheets-based problem logger. It ensures appropriate validation of workflow state before logging an end time, and integrates a utility for updating named range values in the sheet.  

Additionally, this PR refactors `getNamedRangeValue` to leverage the existing `getNamedRange` utility for consistency and error handling.

---

### Changes  
- **Added `onEndClick` function (`src/endWorkflow.js`)**
  - Validates whether an attempt is currently in progress.
  - Alerts the user if no attempt is active, or if an attempt is already marked as done.
  - Sets the current timestamp to the `ControlPanel_EndTime` named range.

- **Created `setNamedRangeValue` utility (`src/sheetUtils/setNamedRangeValue.js`)**
  - Reuses `getNamedRange` to locate a named range and set its value.

- **Refactored `getNamedRangeValue` (`src/sheetUtils/getNamedRangeValue.js`)**
  - Removed redundant direct call to `getRangeByName`.
  - Now consistently uses `getNamedRange` for improved maintainability and error handling.

- **Minor cleanup in `getNamedRange` (`src/sheetUtils/getNamedRange.js`)**
  - Ensured module exports formatting consistency.

---

### Testing  
- Manually validated the following flows in the Google Sheets UI:
  - End button click with no attempt in progress → UI alert.
  - End button click with attempt marked done → UI alert.
  - End button click with active attempt → `ControlPanel_EndTime` updated.

---

### Value  
- Standardizes the way named ranges are accessed and updated across the project.
- Prevents invalid state transitions during workflow execution.
- Sets a foundation for future workflow event handlers with consistent patterns.
