### PR TITLE
fix: Avoid overwriting attempt input formulas with values

### DIFF
--- a/src/optimalWorkflow.js
+++ b/src/optimalWorkflow.js
@@ -16,20 +16,11 @@ function onOptimalClick() {
         return;
     }
 
-    const dropdownFields = [
-        'Solved',
-        'Time Complexity Optimal',
-        'Space Complexity Optimal',
-        'Quality Code'
-    ];
-
-    const inputsRangeName = 'ControlPanel_AttemptInputs';
+    const inputsRangeName = 'ControlPanel_AttemptDropdownInputs';
     const inputsMap = getInputsFromSheetUI(inputsRangeName);
 
-    for (const field of dropdownFields) {
-        if (inputsMap.has(field)) {
-            inputsMap.set(field, 'Yes');
-        }
+    for (const [key] of inputsMap) {
+        inputsMap.set(key, 'Yes');
     }
 
     setInputsOnSheetUI(inputsRangeName, inputsMap);


### PR DESCRIPTION
## Summary

Refactored the optimal attempt workflow to prevent overwriting formulas in the Control Panel sheet. Instead of dynamically handling formulas vs. values in code, a new named range (`ControlPanel_AttemptDropdownInputs`) was created containing only the input cells intended for value updates. The `onOptimalClick` function was updated to reference this new named range.

## Related Issue

N/A

## Changes

- Replaced `ControlPanel_AttemptInputs` with `ControlPanel_AttemptDropdownInputs` in `onOptimalClick`
- Removed the `dropdownFields` array, simplifying the workflow to set all fields within the new named range to `'Yes'`
- Updated loop logic to iterate through all keys in `inputsMap` rather than a filtered subset

## Implementation Details

- The previous approach attempted to selectively set dropdown values while preserving formulas via code logic.
- To reduce complexity and risk of unintentional formula overwrites, created a named range containing only editable input cells.
- This allows safely setting all corresponding fields to `'Yes'` without additional checks.

## Testing

- Manually validated that running the `Optimal` button sets all dropdown inputs to `'Yes'` without affecting formula cells.
- Confirmed that cells outside the new named range retain their formulas and computed values.

## Checklist

- [x] Refactored named range reference
- [x] Removed redundant dropdownFields filtering
- [x] Verified formula cells are unaffected after updates
- [x] Ran manual test for expected behavior

## Notes

This streamlines the optimal workflow, eliminates unnecessary in-code filtering, and leverages Google Sheets' named range functionality for safer, more maintainable UI input handling.
