### PR TITLE
feat: Implement Start Attempt Workflow

### DIFF
--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -43,4 +43,6 @@ function resetAttemptInputs() {
     }
 
     resetInputValues(CONFIG.INPUTS_RANGE_NAME, defaults, clearFields)
+
+    // TODO: dynamically hide Attempt in Progress UI
 }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -1,0 +1,63 @@
+const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
+const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
+const { isAttemptInProgress } = require("./workflowUtils");
+
+/**
+ * Handles the click event for starting a new problem attempt.
+ * 
+ * - Checks if an attempt is already in progress and alerts the user if so.
+ * - Validates that a problem is selected before starting an attempt.
+ * - Sets the attempt's LeetCode ID and start time in the appropriate named ranges.
+ * - Updates the UI to indicate an active attempt.
+ * - TODO: Integrate live timer display.
+ *
+ * @returns {void}
+ */
+function onStartClick() {
+    if (isAttemptInProgress()) {
+        SpreadsheetApp.getUi().alert('Attempt already in progress!');
+        return;
+    }
+    
+    let lcId;
+    try {
+        lcId = getCurrentProblemLcId();
+    } catch (e) {
+        SpreadsheetApp.getUi().alert('Select a problem first.');
+        return;
+    }
+    
+    // TODO: Dynamically show Attempt in Progress UI
+    updateAttemptInProgressUI(lcId);
+
+    // TODO: Show live timer
+}
+
+/**
+ * Retrieves the current problem's LeetCode ID from the named range.
+ * 
+ * @throws {Error} If no LC ID is found in the named range.
+ * @returns {string} The LeetCode ID of the currently selected problem.
+ */
+function getCurrentProblemLcId() {
+    const lcId = getNamedRangeValue('ControlPanel_CurrentProblem_LC_ID');
+    if (!lcId) {
+        throw new Error('Missing LC ID.');
+    }
+
+    return lcId;
+}
+
+/**
+ * Updates the Control Panel UI components to indicate an active attempt.
+ * 
+ * - Sets the attempt's LeetCode ID in the 'ControlPanel_Attempt_LC_ID' named range.
+ * - Sets the start time in the 'ControlPanel_StartTime' named range.
+ *
+ * @param {string} lcId - The LeetCode ID of the problem being attempted.
+ * @returns {void}
+ */
+function updateAttemptInProgressUI(lcId) {
+    setNamedRangeValue('ControlPanel_Attempt_LC_ID', lcId);
+    setNamedRangeValue('ControlPanel_StartTime', new Date());
+}


### PR DESCRIPTION
## Summary

Implemented the `onStartClick` event handler with readability, modularity, and future scalability in mind. Extracted problem ID retrieval into a dedicated `getCurrentProblemLcId` function with error handling, and moved attempt-related named range updates into a new `updateAttemptInProgressUI` function.

## Related Issue

Closes #10 

## Problem-Solving Approach

- Separated validation and UI update responsibilities into their own functions.
- Exception-based control flow for missing problem selection.

## Implementation Details

- Added `getCurrentProblemLcId()` to safely fetch and validate the current problem's LC ID.
- Added `updateAttemptInProgressUI(lcId)` to encapsulate updating relevant named ranges.

## Testing

Manually tested triggering `onStartClick()` with and without a problem selected to confirm correct alert and range update behavior.
