### PR TITLE
feat: Add Problem Count Named Range and Display Count on Selection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,4 +22,10 @@ const MODEL_FIELD_MAPPINGS = {
     }
 }
 
-module.exports = { MODEL_FIELD_MAPPINGS }
+const NAMED_RANGES = {
+    ControlPanel: {
+        ProblemCount: 'ControlPanel_ProblemCount'
+    }
+}
+
+module.exports = { MODEL_FIELD_MAPPINGS, NAMED_RANGES }

--- a/src/selectWorkflow.js
+++ b/src/selectWorkflow.js
@@ -1,5 +1,7 @@
 const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
 const { isAttemptInProgress } = require("./workflowUtils");
+const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
+const { NAMED_RANGES } = require("./constants");
 
 /**
  * Handles the logic when the "Select" button is clicked in the LeetLogger UI.
@@ -15,6 +17,8 @@ function onSelectClick() {
     }
 
     const problems = generateProblemSelectionList();
-    const selectedProblem = problems[0];
-    displayCurrentProblem(selectedProblem);
+    
+    // Display the selection list problem count
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.ProblemCount, problems.length);
+    displayCurrentProblem(problems[0]);
 }


### PR DESCRIPTION
### Summary
Adds a new `NAMED_RANGES` constant to centralize control panel named ranges and enhances the problem selection workflow to display the number of available problems in the UI after selection.

### Related Issue
N/A

### Changes
- Introduced a `NAMED_RANGES` object for named range identifiers
- Updated the problem selection workflow to set and display the problem count in the control panel after a selection is made

### Testing
- Verified that selecting a problem updates the `ControlPanel_ProblemCount` value with the correct number of problems

### Notes
This sets up a pattern for cleanly managing named ranges.
