### PR TITLE
feat: Display problem list progression

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ const MODEL_FIELD_MAPPINGS = {
 
 const NAMED_RANGES = {
     ControlPanel: {
-        ProblemCount: 'ControlPanel_ProblemCount'
+        ProblemListProgress: 'ControlPanel_ProblemListProgress'
     }
 }
 

--- a/src/selectWorkflow.js
+++ b/src/selectWorkflow.js
@@ -1,5 +1,5 @@
 const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
-const { isAttemptInProgress } = require("./workflowUtils");
+const { isAttemptInProgress, displayProblemListProgress } = require("./workflowUtils");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { NAMED_RANGES } = require("./constants");
 
@@ -17,8 +17,8 @@ function onSelectClick() {
     }
 
     const problems = generateProblemSelectionList();
+    const problemIndex = 0;
     
-    // Display the selection list problem count
-    setNamedRangeValue(NAMED_RANGES.ControlPanel.ProblemCount, problems.length);
-    displayCurrentProblem(problems[0]);
+    displayProblemListProgress(problemIndex, problems.length);
+    displayCurrentProblem(problems[problemIndex]);
 }

--- a/src/skipWorkflow.js
+++ b/src/skipWorkflow.js
@@ -1,5 +1,5 @@
 const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
-const { isAttemptInProgress, getCurrentProblemLcId, displayCurrentProblem } = require("./workflowUtils");
+const { isAttemptInProgress, getCurrentProblemLcId, displayCurrentProblem, displayProblemListProgress } = require("./workflowUtils");
 
 /**
  * Handles the skip button click event in the problem control panel.
@@ -35,6 +35,7 @@ function onSkipClick() {
         return;
     }
     
+    displayProblemListProgress(nextIndex, problems.length);
     displayCurrentProblem(problems[nextIndex]);
 }
 

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -1,7 +1,19 @@
 const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
+const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
 const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
-const { MODEL_FIELD_MAPPINGS } = require("./constants");
+const { MODEL_FIELD_MAPPINGS, NAMED_RANGES } = require("./constants");
+
+/**
+ * Displays the current problem's position within the problem list in the Control Panel.
+ *
+ * @param {number} problemIndex - Zero-based index of the current problem in the problem list.
+ * @param {number} problemListCount - Total number of problems in the current selection list.
+ */
+function displayProblemListProgress(problemIndex, problemListCount) {
+    const text = `${problemIndex + 1} of ${problemListCount}`;
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.ProblemListProgress, text);
+}
 
 /**
  * Updates the UI with the selected problem's attributes and latest attempt details.
@@ -77,4 +89,10 @@ function isAttemptDone() {
     return getNamedRangeValue('ControlPanel_EndTime') != '';
 }
 
-module.exports = { displayCurrentProblem, getCurrentProblemLcId, isAttemptInProgress, isAttemptDone }
+module.exports = {
+    displayCurrentProblem,
+    displayProblemListProgress,
+    getCurrentProblemLcId,
+    isAttemptInProgress,
+    isAttemptDone
+}


### PR DESCRIPTION
### Summary
Introduces a new `ProblemListProgress` named range and a `displayProblemListProgress` helper to display the current problem’s position within the selection list in the Control Panel. Updates the selection and skip workflows to reflect problem progression in the UI.

### Related Issue
N/A

### Changes
- Added `ProblemListProgress` to the `NAMED_RANGES` constant
- Created `displayProblemListProgress` helper for displaying problem list position
- Updated `onSelectClick` and `onSkipClick` workflows to display list progress alongside problem selection

### Testing
- Verified that selecting a problem displays `1 of X` in the control panel
- Verified that skipping a problem updates the display to the next index in `X of Y` format

### Notes
Establishes a pattern for centralizing problem list progression display logic for reuse across workflows.
