### PR TITLE
feat: add selection metrics calculation and Control Panel UI updates

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,15 @@ const NAMED_RANGES = {
         PRIORITIZE_TIME_NOT_OPTIMAL: 'ControlPanel_PrioritizeTimeNotOptimal',
         PRIORITIZE_UNATTEMPTED: 'ControlPanel_PrioritizeUnattempted',
         PRIORITIZE_UNSOLVED: 'ControlPanel_PrioritizeUnsolved',
-        PROBLEM_LIST_PROGRESS: 'ControlPanel_ProblemListProgress'
+        PROBLEM_LIST_PROGRESS: 'ControlPanel_ProblemListProgress',
+        SELECTION_METRICS_NEWEST_ATTEMPT_DATE: 'ControlPanel_SelectionMetricsNewestAttemptDate',
+        SELECTION_METRICS_NOT_QUALITY_CODE: 'ControlPanel_SelectionMetricsNotQualityCode',
+        SELECTION_METRICS_NOT_SOLVED: 'ControlPanel_SelectionMetricsNotSolved',
+        SELECTION_METRICS_OLDEST_ATTEMPT_DATE: 'ControlPanel_SelectionMetricsOldestAttemptDate',
+        SELECTION_METRICS_PROBLEMS: 'ControlPanel_SelectionMetricsProblems',
+        SELECTION_METRICS_SPACE_NOT_OPTIMAL: 'ControlPanel_SelectionMetricsSpaceNotOptimal',
+        SELECTION_METRICS_TIME_NOT_OPTIMAL: 'ControlPanel_SelectionMetricsTimeNotOptimal',
+        SELECTION_METRICS_UNATTEMPTED: 'ControlPanel_SelectionMetricsUnattempted',
     },
     TargetTimes: {
         DIFFICULTY: 'TargetTimesDifficulty',

--- a/src/dataModelUtils/calculateSelectionMetrics.js
+++ b/src/dataModelUtils/calculateSelectionMetrics.js
@@ -1,0 +1,83 @@
+/**
+ * Calculates aggregate metrics for a selection of problem attempts.
+ *
+ * Metrics include:
+ * - totalProblems: total number of problems provided
+ * - unattempted: number of problems with undefined startTime
+ * - notSolved: percentage of attempted problems not solved
+ * - timeNotOptimal: percentage of attempted problems with suboptimal time complexity
+ * - spaceNotOptimal: percentage of attempted problems with suboptimal space complexity
+ * - notQualityCode: percentage of attempted problems not marked as quality code
+ * - oldestAttemptDate: earliest startTime among attempted problems, or '' if none
+ * - newestAttemptDate: latest startTime among attempted problems, or '' if none
+ *
+ * @param {Array<Object>} problemAttempts - Array of problem attempt objects.
+ * @param {string|undefined} problemAttempts[].startTime - Timestamp string of the attempt start, or undefined if unattempted.
+ * @param {boolean} [problemAttempts[].solved] - Whether the problem was solved.
+ * @param {boolean} [problemAttempts[].timeComplexityOptimal] - Whether the solution was time complexity optimal.
+ * @param {boolean} [problemAttempts[].spaceComplexityOptimal] - Whether the solution was space complexity optimal.
+ * @param {boolean} [problemAttempts[].qualityCode] - Whether the code met quality standards.
+ * @returns {Object} An object containing calculated metrics.
+ * @returns {number} return.totalProblems
+ * @returns {number} return.unattempted
+ * @returns {number} return.notSolved
+ * @returns {number} return.timeNotOptimal
+ * @returns {number} return.spaceNotOptimal
+ * @returns {number} return.notQualityCode
+ * @returns {Date|string} return.oldestAttemptDate
+ * @returns {Date|string} return.newestAttemptDate
+ */
+function calculateSelectionMetrics(problemAttempts) {
+    let unattemptedCount = 0;
+    let notSolvedCount = 0;
+    let timeNotOptimalCount = 0;
+    let spaceNotOptimalCount = 0;
+    let notQualityCodeCount = 0;
+    let oldestAttemptDate = '';
+    let newestAttemptDate = '';
+
+    for (const problem of problemAttempts) {
+        if (problem.startTime === undefined) {
+            unattemptedCount ++;
+            continue;
+        }
+        if (!problem.solved) notSolvedCount++;
+        if (!problem.timeComplexityOptimal) timeNotOptimalCount++;
+        if (!problem.spaceComplexityOptimal) spaceNotOptimalCount++;
+        if (!problem.qualityCode) notQualityCodeCount++;
+
+        const problemDate = new Date(problem.startTime);
+
+        if (!oldestAttemptDate || problemDate < oldestAttemptDate) oldestAttemptDate = problemDate;
+        if (!newestAttemptDate || problemDate > newestAttemptDate) newestAttemptDate = problemDate;
+    }
+
+    const attemptedCount = problemAttempts.length - unattemptedCount;
+
+    return {
+        totalProblems: problemAttempts.length,
+        unattempted: unattemptedCount,
+        notSolved: calculatePercent(notSolvedCount, attemptedCount),
+        timeNotOptimal: calculatePercent(timeNotOptimalCount, attemptedCount),
+        spaceNotOptimal: calculatePercent(spaceNotOptimalCount, attemptedCount),
+        notQualityCode: calculatePercent(notQualityCodeCount, attemptedCount),
+        oldestAttemptDate: oldestAttemptDate,
+        newestAttemptDate: newestAttemptDate,
+    }
+}
+
+/**
+ * Calculates a percentage value from a count and total attempted count.
+ *
+ * Returns 0 if no attempts were made or if metric count is zero.
+ *
+ * @param {number} metricCount - The count of problems matching the metric.
+ * @param {number} attemptedCount - The total number of attempted problems.
+ * @returns {number} The computed percentage (as a fraction between 0 and 1).
+ */
+function calculatePercent(metricCount, attemptedCount) {
+    if (attemptedCount === 0 || metricCount === 0) return 0;
+    return metricCount / attemptedCount;
+}
+
+module.exports = { calculateSelectionMetrics }

--- a/src/selectWorkflow.js
+++ b/src/selectWorkflow.js
@@ -1,5 +1,5 @@
 const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
-const { isAttemptInProgress, displayProblemListProgress } = require("./workflowUtils");
+const { isAttemptInProgress, displayProblemListProgress, updateSelectionMetrics } = require("./workflowUtils");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { NAMED_RANGES } = require("./constants");
 
@@ -19,6 +19,7 @@ function onSelectClick() {
     const problems = generateProblemSelectionList();
     const problemIndex = 0;
     
+    updateSelectionMetrics(problems);
     displayProblemListProgress(problemIndex, problems.length);
     displayCurrentProblem(problems[problemIndex]);
 }

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -3,6 +3,7 @@ const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
 const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
 const { MODEL_FIELD_MAPPINGS, NAMED_RANGES } = require("./constants");
+const { calculateSelectionMetrics } = require("./dataModelUtils/calculateSelectionMetrics");
 
 /**
  * Displays the current problem's position within the problem list in the Control Panel.
@@ -50,6 +51,21 @@ function displayCurrentProblem(problemAttemptAttributes) {
     setInputsOnSheetUI(latestAttemptAttributesRangeName, latestAttemptAttributes);
 }
 
+function updateSelectionMetrics(problemAttempts) {
+    if (!problemAttempts.length) return;
+
+    const metrics = calculateSelectionMetrics(problemAttempts);
+
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_PROBLEMS, metrics.totalProblems);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_UNATTEMPTED, metrics.unattempted);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_NOT_SOLVED, metrics.notSolved);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_TIME_NOT_OPTIMAL, metrics.timeNotOptimal);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_SPACE_NOT_OPTIMAL, metrics.spaceNotOptimal);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_NOT_QUALITY_CODE, metrics.notQualityCode);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_OLDEST_ATTEMPT_DATE, metrics.oldestAttemptDate);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SELECTION_METRICS_NEWEST_ATTEMPT_DATE, metrics.newestAttemptDate);
+}
+
 /**
  * Retrieves the current problem's LeetCode ID from the named range.
  * 
@@ -90,6 +106,7 @@ function isAttemptDone() {
 }
 
 module.exports = {
+    updateSelectionMetrics,
     displayCurrentProblem,
     displayProblemListProgress,
     getCurrentProblemLcId,

--- a/tests/dataModelUtils/calculateSelectionMetrics.test.js
+++ b/tests/dataModelUtils/calculateSelectionMetrics.test.js
@@ -1,0 +1,107 @@
+const { calculateSelectionMetrics } = require("../../src/dataModelUtils/calculateSelectionMetrics");
+
+describe('calculateSelectionMetrics', () => {
+    it('calculates total problems correctly', () => {
+        const problemAttempts = [{}, {}, {}];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.totalProblems).toBe(3);
+    });
+
+    it('calculates unattempted correctly when all unattempted', () => {
+        const problemAttempts = [{}, {}];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.unattempted).toBe(2);
+    });
+
+    it('calculates unattempted correctly when some unattempted', () => {
+        const problemAttempts = [
+            { startTime: '' },
+            {},
+            { startTime: '' },
+            {},
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.unattempted).toBe(2);
+    });
+
+    it('calculates notSolved correctly', () => {
+        const problemAttempts = [
+            { startTime: '', solved: true },
+            { startTime: '', solved: true },
+            { startTime: '', solved: true },
+            { startTime: '', solved: false },
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.notSolved).toBe(1 / 4);
+    });
+
+    it('calculates timeNotOptimal correctly', () => {
+        const problemAttempts = [
+            { startTime: '', timeComplexityOptimal: true },
+            { startTime: '', timeComplexityOptimal: true },
+            { startTime: '', timeComplexityOptimal: false },
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.timeNotOptimal).toBe(1 / 3);
+    });
+
+    it('calculates spaceNotOptimal correctly', () => {
+        const problemAttempts = [
+            { startTime: '', spaceComplexityOptimal: true },
+            { startTime: '', spaceComplexityOptimal: false },
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.spaceNotOptimal).toBe(1 / 2);
+    });
+
+    it('calculates notQualityCode correctly', () => {
+        const problemAttempts = [
+            { startTime: '', qualityCode: true },
+            { startTime: '', qualityCode: true },
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.notQualityCode).toBe(0);
+    });
+
+    it('calculates oldestAttemptDate correctly', () => {
+        const problemAttempts = [
+            { startTime: 'Tue May 20 18:59:47 GMT-07:00 2025' },
+            { startTime: 'Wed May 21 18:59:47 GMT-07:00 2025' },
+            { startTime: 'Fri May 23 18:59:47 GMT-07:00 2025' },
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.oldestAttemptDate).toEqual(new Date('Tue May 20 18:59:47 GMT-07:00 2025'));
+    });
+
+    it('calculates newestAttemptDate correctly', () => {
+        const problemAttempts = [
+            { startTime: 'Tue May 20 18:59:47 GMT-07:00 2025' },
+            { startTime: 'Wed May 21 18:59:47 GMT-07:00 2025' },
+            { startTime: 'Fri May 23 18:59:47 GMT-07:00 2025' }
+        ];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.newestAttemptDate).toEqual(new Date('Fri May 23 18:59:47 GMT-07:00 2025'));
+    });
+
+    it('returns empty metrics when problem list is empty', () => {
+        const problemAttempts = [];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.unattempted).toBe(0);
+        expect(result.totalProblems).toBe(0);
+        expect(result.notSolved).toBe(0);
+        expect(result.timeNotOptimal).toBe(0);
+        expect(result.spaceNotOptimal).toBe(0);
+        expect(result.notQualityCode).toBe(0);
+        expect(result.oldestAttemptDate).toBe('');
+        expect(result.newestAttemptDate).toBe('');
+    });
+
+    it('handles all unattempted problems without divide-by-zero errors', () => {
+        const problemAttempts = [{}, {}, {}];
+        const result = calculateSelectionMetrics(problemAttempts);
+        expect(result.notSolved).toBe(0);
+        expect(result.timeNotOptimal).toBe(0);
+        expect(result.spaceNotOptimal).toBe(0);
+        expect(result.notQualityCode).toBe(0);
+    });
+});


### PR DESCRIPTION
## Related Issue  
N/A

## Problem  
The Control Panel lacked visibility into selection-level metrics for the currently generated problem list, limiting the ability to make informed decisions about problem set quality and balance.

## Changes  
- Added `calculateSelectionMetrics` utility to compute aggregate metrics for a given problem list.
- Updated `NAMED_RANGES` constants with new named ranges for selection metrics.
- Created `updateSelectionMetrics` function in `workflowUtils` to write calculated metrics to the Sheet UI.
- Integrated `updateSelectionMetrics` into `onSelectClick` workflow.
- Wrote comprehensive unit tests for `calculateSelectionMetrics`.

## Testing  
- Confirmed unit tests for `calculateSelectionMetrics` pass for edge cases and expected scenarios.
- Manually verified that metrics update correctly in the Control Panel upon problem selection.
- Checked that unattempted, not solved, time/space not optimal, not quality code, and date metrics populate as expected in the Sheet UI.

## Value  
This change improves decision-making during problem selection workflows by surfacing immediate, actionable insights about the generated problem set’s overall attempt status and solution quality. It ensures users can quickly identify weaknesses in the selected list and adjust workflows or problem pools accordingly.
