### PR TITLE
feat: automate next problem selection after logging an attempt with restartProblemSelection

### DIFF
--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,4 +1,5 @@
 const { NAMED_RANGES } = require("./constants");
+const { restartProblemSelection } = require("./workflowUtils");
 
 const CONFIG = {
     END_TIME_RANGE_NAME: 'ControlPanel_EndTime',
@@ -9,6 +10,7 @@ const CONFIG = {
 function onLogClick() {
     logAttempt();
     resetAttemptInputs();
+    restartProblemSelection();
 }
 
 function logAttempt() {

--- a/src/selectWorkflow.js
+++ b/src/selectWorkflow.js
@@ -1,14 +1,14 @@
-const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
-const { isAttemptInProgress, displayProblemListProgress, updateCurrentProblem, updateSelectionMetrics } = require("./workflowUtils");
-const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
-const { NAMED_RANGES } = require("./constants");
+const { isAttemptInProgress, restartProblemSelection } = require("./workflowUtils");
 
 /**
  * Handles the logic when the "Select" button is clicked in the LeetLogger UI.
  *
  * - Checks if an attempt is already in progress.  
- * - If not, selects the next problem from the generated problem list.  
- * - Displays the selected problem's attributes on the UI.
+ * - If not, regenerates the problem selection list, updates selection metrics, 
+ *   clears the skip count display, and displays the next problem.
+ * 
+ * This initializes a fresh problem selection session and should be used
+ * when starting a new selection workflow.
  */
 function onSelectClick() {
     if (isAttemptInProgress()) {
@@ -16,10 +16,5 @@ function onSelectClick() {
         return;
     }
 
-    const problems = generateProblemSelectionList();
-    const problemIndex = 0;
-    
-    updateSelectionMetrics(problems);
-    setNamedRangeValue(NAMED_RANGES.ControlPanel.SKIP_COUNT, '');
-    updateCurrentProblem(problems[problemIndex]);
+    restartProblemSelection();
 }

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -6,6 +6,26 @@ const { MODEL_FIELD_MAPPINGS, NAMED_RANGES } = require("./constants");
 const { calculateSelectionMetrics } = require("./dataModelUtils/calculateSelectionMetrics");
 
 /**
+ * Regenerates the problem selection list, updates selection metrics,
+ * clears the skip count display, and displays the next problem.
+ * 
+ * This function is used after workflows where the problem selection 
+ * list may have changed — such as after logging a new attempt or 
+ * initializing a new selection session. Unlike the skip workflow,
+ * this resets skip progress, recalculates metrics based on the 
+ * potentially updated list, and displays the problem at index 0.
+ *
+ * Intended for use in selection workflows where the problem pool 
+ * and associated metrics require refreshing before progression.
+ */
+function restartProblemSelection() {
+    const problems = generateProblemSelectionList();
+    updateSelectionMetrics(problems);
+    updateCurrentProblem(problems[0]);
+    setNamedRangeValue(NAMED_RANGES.ControlPanel.SKIP_COUNT, '');
+}
+
+/**
  * Displays the current problem's position within the problem list in the Control Panel.
  *
  * @param {number} problemIndex - Zero-based index of the current problem in the problem list.
@@ -111,5 +131,6 @@ module.exports = {
     updateSkipCount,
     getCurrentProblemLcId,
     isAttemptInProgress,
-    isAttemptDone
+    isAttemptDone,
+    restartProblemSelection
 }


### PR DESCRIPTION
## Related Issue
N/A

## Problem
After logging a new attempt, the workflow did not automatically select the next problem. 

## Changes
- Created a new `restartProblemSelection()` function in `workflowUtils.js` that regenerates the problem selection list, updates selection metrics, clears skip count, and displays the first problem in the updated list.  
- Updated `logWorkflow.js` to call `restartProblemSelection()` after logging an attempt, enabling automatic selection of the next problem without duplicating logic.  
- Refactored `selectWorkflow.js` to use `restartProblemSelection()` when starting a new selection session, consolidating selection reset logic.  

## Testing
- Confirmed that after logging an attempt, the next problem is automatically selected and displayed with updated metrics.  
- Confirmed that starting a new selection session via the Select button correctly resets and displays the problem list.  
- Manual testing on Google Sheets UI verified no regressions in attempt logging or problem selection workflows.

## Value
Automates progression to the next problem after logging an attempt, improving user workflow and experience. Centralizes problem selection reset logic, increasing code maintainability and reducing duplication. Enables consistent UI and metric updates across workflows.
