### PR TITLE
fix: handle empty problem selection list and clear current problem UI state

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,3 +1,0 @@
-function myFunction() {
-  
-}

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,8 @@ const MODEL_FIELD_MAPPINGS = {
 const NAMED_RANGES = {
     ControlPanel: {
         ATTEMPT_OPTIMAL_INPUTS: 'ControlPanel_AttemptOptimalInputs',
+        CURRENT_PROBLEM_ATTRIBUTES: 'ControlPanel_CurrentProblem_ProblemAttributes',
+        CURRENT_PROBLEM_LATEST_ATTEMPT_ATTRIBUTES: 'ControlPanel_CurrentProblem_LatestAttemptAttributes',
         DOMINANT_TOPIC: 'ControlPanel_DominantTopic',
         DIFFICULTY: 'ControlPanel_Difficulty',
         PRIORITIZE_NOT_QUALITY_CODE: 'ControlPanel_PrioritizeNotQualityCode',

--- a/src/sheetUtils/resetInputValues.js
+++ b/src/sheetUtils/resetInputValues.js
@@ -5,16 +5,16 @@
  *
  * @param {string} rangeName - The name of the range in the sheet containing the input fields.
  * @param {Object.<string, string>} defaultsMap - An object mapping field names to their default values.
- * @param {string[]} clearFields - An array of field names to be cleared (set to an empty string).
+ * @param {string[]} subsetFields - Array of input keys to clear; if empty, clears all.
  * @returns {void}
  */
-function resetInputValues(rangeName, defaultsMap, clearFields) {
+function resetInputValues(rangeName, defaultsMap = {}, subsetFields = []) {
     const inputsMap = getInputsFromSheetUI(rangeName);
 
     for (const key of inputsMap.keys()) {
-        if (defaultsMap.hasOwnProperty(key)) {
-            inputsMap.set(key, defaultsMap[key]);
-      } else if (clearFields.includes(key)) {
+      if (defaultsMap.hasOwnProperty(key)) {
+        inputsMap.set(key, defaultsMap[key]);
+      } else if (!subsetFields.length || subsetFields.includes(key)) {
         inputsMap.set(key, '');
       }
     }


### PR DESCRIPTION
## related issue
N/A — bug was discovered during workflow testing.

## Problem
When clicking "Select" with no problems available under the current filters, the workflow would throw an error when attempting to access `problems[0]`. Additionally, the UI was left in an inconsistent state, with stale selection metrics and problem attribute values displayed.

## Changes
- Added a guard clause in `restartProblemSelection` to:
  - Only call `updateCurrentProblem` if problems exist.
  - Call `clearCurrentProblem` if the list is empty.
- Added a new `clearCurrentProblem` function that:
  - Resets both `CURRENT_PROBLEM_ATTRIBUTES` and `CURRENT_PROBLEM_LATEST_ATTEMPT_ATTRIBUTES`.
  - Clears the `TIME_SINCE_CURRENT_PROBLEM` field.
- Updated `updateCurrentProblem` to consistently use `NAMED_RANGES` constants rather than hardcoded string names.
- In `updateSelectionMetrics`, now assigns `'None'` if no oldest/newest attempt date exists instead of formatting `undefined`.
- Refactored `resetInputValues` to:
  - Replace `clearFields` param with `subsetFields`, defaulting to an empty array.
  - Clear all fields when `subsetFields` is empty, or selectively clear specified fields.
  - Simplify logic for setting default values or empty strings.

## Testing
- Ran `restartProblemSelection()` with and without available problems.
- Confirmed no errors are thrown when no problems are returned.
- Verified that the UI input ranges for current problem attributes and latest attempt attributes are cleared when appropriate.
- Confirmed selection metrics display `0` or `'None'` as expected in empty state.

## Value
- Prevents runtime errors in selection workflow when no problems match the active filters.
- Maintains accurate, reflective UI state by clearing stale problem details and metrics.
