### PR TITLE
fix: Remove checkbox fields from required fields

### DIFF
--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -19,10 +19,6 @@ function logAttempt() {
         'Start Time',
         'End Time',
         'Duration Minutes',
-        'Solved',
-        'Time Complexity Optimal',
-        'Space Complexity Optimal',
-        'Quality Code'
     ];
 
     const inputValues = getInputValues(CONFIG.INPUTS_RANGE_NAME, requiredFields);


### PR DESCRIPTION
## Problem
Unchecked checkboxes on the UI were being incorrectly caught as missing required fields. This is due to the values being read in bulk with `getValues()` on the range and a `FALSE` state being interpreted as `''`. Some options to resolve this were to switch the checkboxes to dropdown with "yes"/"no" were '' would be treated as invalid or leaving the checkboxes but converting '' to TRUE/FALSE or treat '' as a valid state equal to FALSE. Checkboxes are a better design choice on the front-end due to their binary choice nature and the backend will work as intended with '' instead of FALSE, so the minimal changes required are to remove the checkbox fields from the list of required fields.

## Changes
Remove all checkbox fields from `requiredFields`

## Testing
Tested that attempts are able to log with both checked and unchecked boxes.