### PR TITLE
fix: Handle time since latest attempt for unattempted

### DIFF
--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -78,6 +78,8 @@ function updateCurrentProblem(problemAttemptAttributes) {
     if (problemAttemptAttributes.startTime) {
         const timeSince = formatTimeSince(problemAttemptAttributes.startTime);
         setNamedRangeValue(NAMED_RANGES.ControlPanel.TIME_SINCE_CURRENT_PROBLEM, timeSince);
+    } else {
+        setNamedRangeValue(NAMED_RANGES.ControlPanel.TIME_SINCE_CURRENT_PROBLEM, 'Unattempted');
     }
 }
 


### PR DESCRIPTION
## Problem
The time since latest attempt was being conditionally updated when an attempt existed, but not cleared otherwise. As a result, if there was no latest attempt, the time since string remained from the previous problem.

## Changes
Set the time since latest attempt to "Unattempted" to reflect that the problem has not been attempted and therefore no latest attempt exists.