### PR TITLE
fix: treat only explicit false values as not optimal in prioritization check

### DIFF
--- a/src/dataModelUtils/problemAttemptComparator.js
+++ b/src/dataModelUtils/problemAttemptComparator.js
@@ -57,9 +57,9 @@ function problemAttemptComparator(a, b, config) {
  */
 function hasNotOptimalAndPrioritized(item, config) {
   return [
-    !item.timeComplexityOptimal && config.prioritizeTimeNotOptimal,
-    !item.spaceComplexityOptimal && config.prioritizeSpaceNotOptimal,
-    !item.qualityCode && config.prioritizeCodeQualityNotOptimal
+    item.timeComplexityOptimal === false && config.prioritizeTimeNotOptimal,
+    item.spaceComplexityOptimal === false && config.prioritizeSpaceNotOptimal,
+    item.qualityCode === false && config.prioritizeCodeQualityNotOptimal
   ].some(Boolean);
 }
 


### PR DESCRIPTION
## Related Issue
N/A

## Problem
The `hasNotOptimalAndPrioritized` function was previously using `!item.property` to check for not optimal values. In JavaScript, this treats `false`, `undefined`, `null`, and empty strings as falsy. Since some historical data lacked these fields (blank in Google Sheets), the logic incorrectly treated missing values as `false`, causing them to be prioritized unintentionally.

## Changes
- Replaced `!item.property` checks with explicit `item.property === false` comparisons to ensure only explicit `false` values trigger prioritization.
- Removed the old `!item.property` checks entirely.

## Testing
Manually confirmed that records with missing or blank values no longer trigger prioritization, and only explicit `false` values do when the corresponding config flag is `true`.

## Value
Prevents false positives when prioritizing records by ensuring only explicit `false` values are treated as not optimal. Makes the prioritization logic resilient to incomplete or partially populated data, eliminating reliance on JavaScript's type coercion.
