### PR TITLE
fix: Use explicit false for counting selection metrics

### DIFF
--- a/src/dataModelUtils/calculateSelectionMetrics.js
+++ b/src/dataModelUtils/calculateSelectionMetrics.js
@@ -41,10 +41,10 @@ function calculateSelectionMetrics(problemAttempts) {
             unattemptedCount ++;
             continue;
         }
-        if (!problem.solved) notSolvedCount++;
-        if (!problem.timeComplexityOptimal) timeNotOptimalCount++;
-        if (!problem.spaceComplexityOptimal) spaceNotOptimalCount++;
-        if (!problem.qualityCode) notQualityCodeCount++;
+        if (problem.solved === false) notSolvedCount++;
+        if (problem.timeComplexityOptimal === false) timeNotOptimalCount++;
+        if (problem.spaceComplexityOptimal === false) spaceNotOptimalCount++;
+        if (problem.qualityCode === false) notQualityCodeCount++;
 
         const problemDate = new Date(problem.startTime);
 
@@ -57,27 +57,13 @@ function calculateSelectionMetrics(problemAttempts) {
     return {
         totalProblems: problemAttempts.length,
         unattempted: unattemptedCount,
-        notSolved: calculatePercent(notSolvedCount, attemptedCount),
-        timeNotOptimal: calculatePercent(timeNotOptimalCount, attemptedCount),
-        spaceNotOptimal: calculatePercent(spaceNotOptimalCount, attemptedCount),
-        notQualityCode: calculatePercent(notQualityCodeCount, attemptedCount),
+        notSolved: notSolvedCount,
+        timeNotOptimal: timeNotOptimalCount,
+        spaceNotOptimal: spaceNotOptimalCount,
+        notQualityCode: notQualityCodeCount,
         oldestAttemptDate: oldestAttemptDate,
         newestAttemptDate: newestAttemptDate,
     }
-}
-
-/**
- * Calculates a percentage value from a count and total attempted count.
- *
- * Returns 0 if no attempts were made or if metric count is zero.
- *
- * @param {number} metricCount - The count of problems matching the metric.
- * @param {number} attemptedCount - The total number of attempted problems.
- * @returns {number} The computed percentage (as a fraction between 0 and 1).
- */
-function calculatePercent(metricCount, attemptedCount) {
-    if (attemptedCount === 0 || metricCount === 0) return 0;
-    return metricCount / attemptedCount;
 }
 
 module.exports = { calculateSelectionMetrics }

--- a/tests/dataModelUtils/calculateSelectionMetrics.test.js
+++ b/tests/dataModelUtils/calculateSelectionMetrics.test.js
@@ -32,7 +32,7 @@ describe('calculateSelectionMetrics', () => {
             { startTime: '', solved: false },
         ];
         const result = calculateSelectionMetrics(problemAttempts);
-        expect(result.notSolved).toBe(1 / 4);
+        expect(result.notSolved).toBe(1);
     });
 
     it('calculates timeNotOptimal correctly', () => {
@@ -42,7 +42,7 @@ describe('calculateSelectionMetrics', () => {
             { startTime: '', timeComplexityOptimal: false },
         ];
         const result = calculateSelectionMetrics(problemAttempts);
-        expect(result.timeNotOptimal).toBe(1 / 3);
+        expect(result.timeNotOptimal).toBe(1);
     });
 
     it('calculates spaceNotOptimal correctly', () => {
@@ -51,7 +51,7 @@ describe('calculateSelectionMetrics', () => {
             { startTime: '', spaceComplexityOptimal: false },
         ];
         const result = calculateSelectionMetrics(problemAttempts);
-        expect(result.spaceNotOptimal).toBe(1 / 2);
+        expect(result.spaceNotOptimal).toBe(1);
     });
 
     it('calculates notQualityCode correctly', () => {


### PR DESCRIPTION
## Related Issue
N/A

## Problem
The `calculateSelectionMetrics` utility was using `!field` checks for problem metrics, which incorrectly treated `null` or `undefined` values as `false`. This misrepresented the actual state of problem attempts. Additionally, the function was designed to return percentages for metrics like `notSolved`, `timeNotOptimal`, `spaceNotOptimal`, and `notQualityCode` relative to the number of attempted problems. 

While percentages seemed appropriate for comparing across different selections with varying attempt counts, in this particular view we only display a single selection at a time and only consider the latest attempt per problem. This means percentages added unnecessary noise, as the number of attempts per selection is fixed and eventually all problems would trend toward optimal values. What’s actually useful here is a count of remaining issues to address — providing a clear progress indicator of how many problems still need to be "fixed" within the current selection.

A separate view will later provide a proper comparative percentage breakdown across topics, using all attempts, to truly surface weak areas.

## Changes
- Replaced `!field` checks with explicit `=== false` comparisons to avoid incorrectly treating `null` or `undefined` as `false`.
- Updated `calculateSelectionMetrics` to return raw counts for `notSolved`, `timeNotOptimal`, `spaceNotOptimal`, and `notQualityCode` instead of percentages.
- Updated unit tests in `calculateSelectionMetrics.test.js` to assert against raw count values, matching the new return structure.

## Testing
- Adjusted existing tests to reflect expected raw counts.
- Ran the test suite to confirm correctness.

## Value
Prevents misclassification of unset fields in problem attempts and replaces percentage-based metrics with raw counts tailored for this single-selection, latest-attempt view. This provides a more actionable, intuitive progress indicator for improving problem attempts within a selection. Future comparative analysis across topics will be handled by a separate aggregated percentage-based view.
