### PR TITLE
feat: add latest attempts view and named range writer utility

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,10 @@ const NAMED_RANGES = {
         SKIP_COUNT: 'ControlPanel_SkipCount',
         TIME_SINCE_CURRENT_PROBLEM: 'ControlPanel_TimeSinceCurrentProblem',
     },
+    LatestAttempts: {
+        ATTEMPTS: 'LatestAttempts_Attempts',
+        COUNT: 'LatestAttempts_Count',
+    },
     TargetTimes: {
         DIFFICULTY: 'TargetTimesDifficulty',
         MAX_MINUTES: 'TargetTimesMaxMinutes',

--- a/src/sheetUtils/writeToNamedRangeWithHeaders.js
+++ b/src/sheetUtils/writeToNamedRangeWithHeaders.js
@@ -1,0 +1,44 @@
+/**
+ * Writes a list of objects to a named range in the active spreadsheet,
+ * preserving the first row (headers) of the range. 
+ * Each object’s properties are mapped to columns based on the header names.
+ * If there are fewer objects than data rows, remaining rows are cleared.
+ *
+ * @param {Object[]} objects - Array of objects to write. Each key should match a header in the first row of the named range.
+ * @param {string} rangeName - The name of the range to write to. Must include headers in the first row.
+ */
+function writeToNamedRangeWithHeaders(objects, rangeName) {
+    const range = getNamedRange(rangeName);
+    const numRows = range.getNumRows();
+    const numCols = range.getNumColumns();
+    const rawHeaders = range.getValues()[0].map(h => h.trim());
+    const headers = toCamelCaseHeaders(rawHeaders);
+
+    const dataRows = numRows - 1;
+    const dataRange = range.offset(1, 0, dataRows, numCols);
+
+    const values = objects.slice(0, dataRows).map(obj => 
+        headers.map(header => obj[header] !== undefined ? obj[header] : '')
+    );
+
+    while (values.length < dataRows) {
+        values.push(new Array(numCols).fill(''));
+    }
+
+    dataRange.setValues(values);
+}
+
+function toCamelCaseHeaders(headers) {
+  return headers.map(str => {
+    const words = str.trim().split(/\s+/);
+    return words
+      .map((word, index) => {
+        const lower = word.toLowerCase();
+        if (index === 0) return lower;
+        return lower.charAt(0).toUpperCase() + lower.slice(1);
+      })
+      .join('');
+  });
+}
+
+module.exports = { writeToNamedRangeWithHeaders }

--- a/src/views/latestAttempts.js
+++ b/src/views/latestAttempts.js
@@ -1,0 +1,54 @@
+const { NAMED_RANGES, MODEL_FIELD_MAPPINGS } = require("../constants");
+const { getModelDataFromSheet } = require("../sheetUtils/getModelDataFromSheet");
+const { getNamedRangeValue } = require("../sheetUtils/getNamedRangeValue");
+const { writeToNamedRangeWithHeaders } = require("../sheetUtils/writeToNamedRangeWithHeaders");
+const { convertArrayToObject } = require("../utils/convertArrayToObject");
+
+function onLatestAttemptsUpdateClick() {
+    const count = getNamedRangeValue(NAMED_RANGES.LatestAttempts.COUNT);
+    if (!count) {
+        SpreadsheetApp.getUi().alert('Count required.');
+        return;
+    }
+
+    const topAttempts = getTopAttempts(count);
+    const problemIds = topAttempts.map(obj => obj.lcId);
+    const problemsById = getProblemsDataById(new Set(problemIds));
+
+    for (const attemptObj of topAttempts) {
+        const problemObj = problemsById[attemptObj.lcId];
+        if (problemObj) {
+            Object.assign(attemptObj, problemObj);
+        }
+    }
+
+    writeToNamedRangeWithHeaders(topAttempts, NAMED_RANGES.LatestAttempts.ATTEMPTS);
+}
+
+function getProblemsDataById(problemIdSet) {
+    const [problemHeaders, ...problemsData] = getModelDataFromSheet('Problem');
+    const lcIdIndex = problemHeaders.indexOf('lcId');
+    const problemsDataById = {};
+    
+    for (const row of problemsData) {
+        const lcId = row[lcIdIndex]
+        if (problemIdSet.has(lcId)) {
+            problemsDataById[lcId] = convertArrayToObject(problemHeaders, row);
+        }
+    }
+
+    return problemsDataById;
+}
+
+function getTopAttempts(count) {
+    const [attemptHeaders, ...attemptsData] = getModelDataFromSheet('Attempt');
+    const startTimeIndex = attemptHeaders.indexOf('startTime');
+
+    attemptsData.sort((a, b) => {
+        const aDate = new Date(a[startTimeIndex]);
+        const bDate = new Date(b[startTimeIndex]);
+        return bDate - aDate;
+    });
+
+    return attemptsData.slice(0, count).map(row => convertArrayToObject(attemptHeaders, row));
+}


### PR DESCRIPTION
## Related Issue

N/A — operational enhancement for tracking recent attempts.

## Problem

Previously, I had no easy way to view the most recent LeetCode attempts to identify problems where I might have had suboptimal misses (unsolved or inefficient code). This made it cumbersome to manually check selections for problems worth retrying.

## Changes

- Added `NAMED_RANGES.LatestAttempts` entries for `ATTEMPTS` and `COUNT`.
- Created `writeToNamedRangeWithHeaders` utility to write object arrays to a named range, preserving headers and clearing remaining rows.
- Implemented `onLatestAttemptsUpdateClick` in `src/views/latestAttempts.js` to:
  - Fetch the latest `count` attempts sorted by `startTime`.
  - Merge problem metadata into each attempt.
  - Write the result to the `LatestAttempts_Attempts` named range.

## Testing

- Manually verified that triggering `onLatestAttemptsUpdateClick` with a valid count populates the named range with the latest attempts.
- Confirmed problem metadata is accurately merged into each attempt.
- Validated behavior with zero and non-zero counts.

## Value

Enables a quick operational view of the most recent problem attempts, allowing me to immediately identify problems worth retrying due to misses or suboptimal performance — removing the need to manually scan through multiple selections.
