### PR TITLE
refactor: add single and group selection start workflows and parameterize attempt tracking utilities

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,12 @@ const MODEL_FIELD_MAPPINGS = {
 }
 
 const NAMED_RANGES = {
+    AttemptInProgress: {
+        END_TIME: 'AttemptInProgress_EndTime',
+        PROBLEM_ATTRIBUTES: 'AttemptInProgress_ProblemAttributes',
+        PROGRESS: 'AttemptInProgress_Progress',
+        START_TIME: 'AttemptInProgress_StartTime',
+    },
     ControlPanel: {
         ATTEMPT_OPTIMAL_INPUTS: 'ControlPanel_AttemptOptimalInputs',
         CURRENT_PROBLEM_ATTRIBUTES: 'ControlPanel_CurrentProblem_ProblemAttributes',
@@ -63,6 +69,9 @@ const NAMED_RANGES = {
         ORDER: 'DifficultyCounts_Order',
         TIMEFRAME: 'DifficultyCounts_Timeframe',
     },
+    GroupSelection: {
+        PROBLEM_ATTRIBUTES: 'GroupSelection_ProblemAttributes',
+    },
     LatestAttempts: {
         ATTEMPTS: 'LatestAttempts_Attempts',
         COUNT: 'LatestAttempts_Count',
@@ -71,7 +80,6 @@ const NAMED_RANGES = {
         LATEST_ATTEMPT_ATTRIBUTES: 'SingleSelection_LatestAttemptAttributes',
         PROBLEM_ATTRIBUTES: 'SingleSelection_ProblemAttributes',
         PROBLEM_SEARCH_INPUTS: 'SingleSelection_ProblemSearchInputs',
-        SELECTED_LC_ID: 'SingleSelection_SelectedLCID',
         TIME_SINCE: 'SingleSelection_TimeSince',
     },
     TargetTimes: {
@@ -81,8 +89,13 @@ const NAMED_RANGES = {
     }
 }
 
+const SHEET_NAMES = {
+    ATTEMPT_IN_PROGRESS: 'AttemptInProgress',
+}
+
 module.exports = {
     DOMINANT_TOPICS,
     MODEL_FIELD_MAPPINGS,
     NAMED_RANGES,
+    SHEET_NAMES,
  }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -1,3 +1,6 @@
+const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
+const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
+const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { isAttemptInProgress, getCurrentProblemLcId } = require("./workflowUtils");
 
@@ -33,15 +36,72 @@ function onStartClick() {
 }
 
 /**
- * Updates the Control Panel UI components to indicate an active attempt.
- * 
- * - Sets the attempt's LeetCode ID in the 'ControlPanel_Attempt_LC_ID' named range.
- * - Sets the start time in the 'ControlPanel_StartTime' named range.
+ * Starts a problem attempt from the Group Selection view.
  *
- * @param {string} lcId - The LeetCode ID of the problem being attempted.
+ * Retrieves the problem attributes from the Group Selection control panel section  
+ * and initiates the attempt workflow.
+ *
  * @returns {void}
  */
-function updateAttemptInProgressUI(lcId) {
-    setNamedRangeValue('ControlPanel_Attempt_LC_ID', lcId);
-    setNamedRangeValue('ControlPanel_StartTime', new Date());
+function onGroupSelectionStartClick() {
+    startWorkflow(NAMED_RANGES.GroupSelection.PROBLEM_ATTRIBUTES);
+}
+
+/**
+ * Starts a problem attempt from the Single Selection view.
+ *
+ * Retrieves the problem attributes from the Single Selection control panel section  
+ * and initiates the attempt workflow.
+ *
+ * @returns {void}
+ */
+function onSingleSelectionStartClick() {
+    startWorkflow(NAMED_RANGES.SingleSelection.PROBLEM_ATTRIBUTES);
+}
+
+/**
+ * Starts a problem attempt workflow by verifying readiness and transitioning to the Attempt In Progress sheet.
+ *
+ * - Validates that no other attempt is already in progress.
+ * - Ensures a problem has been selected (checks for a valid LC ID).
+ * - Activates the Attempt In Progress sheet.
+ * - Updates the Attempt In Progress UI components with the selected problem's attributes.
+ *
+ * @param {string} problemAttributesRangeName - The named range for the problem attributes section in the UI.
+ * @returns {void}
+ */
+function startWorkflow(problemAttributesRangeName) {
+    if (isAttemptInProgress()) {
+        SpreadsheetApp.getUi().alert('Attempt already in progress!');
+        return;
+    }
+
+    const problemAttributes = getInputsFromSheetUI(problemAttributesRangeName);
+    if (!problemAttributes.get('LC ID')) {
+        SpreadsheetApp.getUi().alert('Select a problem first.');
+        return;
+    }
+    
+    SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS).activate();
+    updateAttemptInProgressUI(problemAttributes);
+}
+
+/**
+ * Updates the Attempt In Progress UI components to reflect the selected problem.
+ *
+ * - Transfers the problem's attribute values to the Attempt In Progress attributes section.
+ * - Sets the current start time in the Attempt In Progress start time field.
+ *
+ * @param {Map<string, string>} problemAttributes - A map of problem attribute keys and values for the selected problem.
+ * @returns {void}
+ */
+function updateAttemptInProgressUI(problemAttributes) {
+    const attemptProblemAttributes = getInputsFromSheetUI(NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES);
+    for (const key of attemptProblemAttributes.keys()) {
+        if (problemAttributes.has(key)) {
+            attemptProblemAttributes.set(key, problemAttributes.get(key));
+        }
+    }
+    setInputsOnSheetUI(NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES, attemptProblemAttributes);
+    setNamedRangeValue(NAMED_RANGES.AttemptInProgress.START_TIME, new Date());
 }

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -136,8 +136,8 @@ function updateSelectionMetrics(problemAttempts) {
  * @throws {Error} If no LC ID is found in the named range.
  * @returns {string} The LeetCode ID of the currently selected problem.
  */
-function getCurrentProblemLcId() {
-    const lcId = getNamedRangeValue('ControlPanel_CurrentProblem_LC_ID');
+function getCurrentProblemLcId(rangeName) {
+    const lcId = getNamedRangeValue(rangeName);
     if (!lcId) {
         throw new Error('Missing LC ID.');
     }
@@ -148,25 +148,25 @@ function getCurrentProblemLcId() {
 /**
  * Checks whether a LeetLogger problem attempt is currently in progress.
  *
- * This is determined by checking if the 'ControlPanel_StartTime' named range
+ * This is determined by checking if the progress value named range
  * in the sheet has a non-empty value.
  *
  * @returns {boolean} True if an attempt is in progress, false otherwise.
  */
 function isAttemptInProgress() {
-    return getNamedRangeValue('ControlPanel_StartTime') != '';
+    return getNamedRangeValue(NAMED_RANGES.AttemptInProgress.PROGRESS) != '';
 }
 
 /**
  * Checks whether the current LeetLogger problem attempt has been completed.
  *
- * This is determined by checking if the 'ControlPanel_EndTime' named range
+ * This is determined by checking if the end time value named range
  * in the sheet has a non-empty value.
  *
  * @returns {boolean} True if the attempt is complete, false otherwise.
  */
 function isAttemptDone() {
-    return getNamedRangeValue('ControlPanel_EndTime') != '';
+    return getNamedRangeValue(NAMED_RANGES.AttemptInProgress.END_TIME) != '';
 }
 
 module.exports = {


### PR DESCRIPTION
## Related Issue
_No related issue tracked yet_

## Problem
The application previously lacked a start workflow handler for the new **Single Selection** problem selection view. Additionally, the attempt progress tracking utilities (`isAttemptInProgress`, `isAttemptDone`, `getCurrentProblemLcId`) relied on hardcoded control panel named ranges, which restricted flexibility and reusability across multiple selection workflows like Single Selection and Group Selection.

## Changes
- Added new `onSingleSelectionStartClick` and `onGroupSelectionStartClick` handlers to `startWorkflow.js` to support starting problem attempts from both selection modes.
- Refactored `startWorkflow` to accept a problem attributes range name, removing hardcoded control panel dependencies.
- Updated `updateAttemptInProgressUI` to initialize attempt attributes in the **AttemptInProgress** sheet section using the new `NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES`.
- Added `AttemptInProgress` and `GroupSelection` named ranges to `constants.js`.
- Parameterized `getCurrentProblemLcId` to accept a range name instead of using a fixed control panel range.
- Refactored `isAttemptInProgress` and `isAttemptDone` to check named ranges defined in `NAMED_RANGES.AttemptInProgress` instead of hardcoded values.

## Testing
- Manually tested starting problem attempts from both Single Selection and Group Selection views.
- Confirmed correct initialization of Attempt In Progress UI components and named ranges.
- Verified that progress tracking and completion checks function correctly with the new named ranges.

## Value
This enables direct problem attempts from the new **Single Selection** workflow and lays the groundwork for future **Group Selection** workflows. It also makes the progress tracking utilities reusable and decoupled from the hardcoded control panel rang
