### PR TITLE
refactor: migrate attempt workflows to new Attempt In Progress UI structure

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,7 +36,11 @@ const MODEL_FIELD_MAPPINGS = {
 
 const NAMED_RANGES = {
     AttemptInProgress: {
+        DIFFICULTY: 'AttemptInprogress_Difficulty',
+        DOMINANT_TOPIC: 'AttemptInProgress_DominantTopic',
         END_TIME: 'AttemptInProgress_EndTime',
+        INPUTS: 'AttemptInProgress_AttemptInputs',
+        OPTIMAL_INPUTS: 'AttemptInProgress_OptimalInputs',
         PROBLEM_ATTRIBUTES: 'AttemptInProgress_ProblemAttributes',
         PROGRESS: 'AttemptInProgress_Progress',
         START_TIME: 'AttemptInProgress_StartTime',
@@ -90,6 +94,7 @@ const NAMED_RANGES = {
 }
 
 const SHEET_NAMES = {
+    ATTEMPTS: 'Attempts',
     ATTEMPT_IN_PROGRESS: 'AttemptInProgress',
 }
 

--- a/src/endWorkflow.js
+++ b/src/endWorkflow.js
@@ -1,5 +1,6 @@
 const { isAttemptDone, isAttemptInProgress } = require("./workflowUtils");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
+const { NAMED_RANGES } = require("./constants");
 
 function onEndClick() {
     if (!isAttemptInProgress()) {
@@ -12,5 +13,5 @@ function onEndClick() {
         return;
     }
 
-    setNamedRangeValue('ControlPanel_EndTime', new Date());
+    setNamedRangeValue(NAMED_RANGES.AttemptInProgress.END_TIME, new Date());
 }

--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,11 +1,7 @@
-const { NAMED_RANGES } = require("./constants");
+const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
+const { getInputValues } = require("./sheetUtils/getInputValues");
+const { resetInputValues } = require("./sheetUtils/resetInputValues");
 const { restartProblemSelection } = require("./workflowUtils");
-
-const CONFIG = {
-    END_TIME_RANGE_NAME: 'ControlPanel_EndTime',
-    INPUTS_RANGE_NAME: 'ControlPanel_AttemptInputs',
-    SHEET_NAME: 'Attempts',
-  };
 
 function onLogClick() {
     logAttempt();
@@ -21,9 +17,9 @@ function logAttempt() {
         'Duration Minutes',
     ];
 
-    const inputValues = getInputValues(CONFIG.INPUTS_RANGE_NAME, requiredFields);
+    const inputValues = getInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, requiredFields);
 
-    appendRowToSheet(CONFIG.SHEET_NAME, inputValues);
+    appendRowToSheet(SHEET_NAMES.ATTEMPTS, inputValues);
 }
 
 function resetAttemptInputs() {
@@ -35,23 +31,25 @@ function resetAttemptInputs() {
     ]
 
     const defaults = {
-        'Duration Minutes': `=if(${CONFIG.END_TIME_RANGE_NAME}="","",(${CONFIG.END_TIME_RANGE_NAME}-ControlPanel_StartTime)*1440)`,
-        'Cap Minutes': `=index(
+        'Duration Minutes': `=if(
+            ${NAMED_RANGES.AttemptInProgress.END_TIME}="","",
+            (${NAMED_RANGES.AttemptInProgress.END_TIME}-${NAMED_RANGES.AttemptInProgress.START_TIME})*1440
+            )`,
+        'Cap Minutes': `=iferror(index(
             ${NAMED_RANGES.TargetTimes.MAX_MINUTES},
             match(
-                ${NAMED_RANGES.ControlPanel.DOMINANT_TOPIC}&${NAMED_RANGES.ControlPanel.DIFFICULTY},
+                ${NAMED_RANGES.AttemptInProgress.DOMINANT_TOPIC}&${NAMED_RANGES.AttemptInProgress.DIFFICULTY},
                 ${NAMED_RANGES.TargetTimes.TOPIC}&${NAMED_RANGES.TargetTimes.DIFFICULTY},
                 0
             ),
             1
-        )`,
+        ),"")`,
         'Solved': false,
         'Time Complexity Optimal': false,
         'Space Complexity Optimal': false,
         'Quality Code': false,
     }
 
-    resetInputValues(CONFIG.INPUTS_RANGE_NAME, defaults, clearFields)
-
-    // TODO: dynamically hide Attempt in Progress UI
+    resetInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, defaults, clearFields);
+    resetInputValues(NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES);
 }

--- a/src/optimalWorkflow.js
+++ b/src/optimalWorkflow.js
@@ -17,11 +17,11 @@ function onOptimalClick() {
         return;
     }
     
-    const inputsMap = getInputsFromSheetUI(NAMED_RANGES.ControlPanel.ATTEMPT_OPTIMAL_INPUTS);
+    const inputsMap = getInputsFromSheetUI(NAMED_RANGES.AttemptInProgress.OPTIMAL_INPUTS);
 
     for (const [key] of inputsMap) {
         inputsMap.set(key, true);
     }
 
-    setInputsOnSheetUI(NAMED_RANGES.ControlPanel.ATTEMPT_OPTIMAL_INPUTS, inputsMap);
+    setInputsOnSheetUI(NAMED_RANGES.AttemptInProgress.OPTIMAL_INPUTS, inputsMap);
 }

--- a/src/sheetUtils/getInputValues.js
+++ b/src/sheetUtils/getInputValues.js
@@ -18,3 +18,5 @@ function getInputValues(rangeName, requiredFields) {
 
     return Array.from(inputsMap.values());
 }
+
+module.exports = { getInputValues }

--- a/src/sheetUtils/resetInputValues.js
+++ b/src/sheetUtils/resetInputValues.js
@@ -21,3 +21,5 @@ function resetInputValues(rangeName, defaultsMap = {}, subsetFields = []) {
 
     setInputsOnSheetUI(rangeName, inputsMap);
 }
+
+module.exports = { resetInputValues }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -5,37 +5,6 @@ const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { isAttemptInProgress, getCurrentProblemLcId } = require("./workflowUtils");
 
 /**
- * Handles the click event for starting a new problem attempt.
- * 
- * - Checks if an attempt is already in progress and alerts the user if so.
- * - Validates that a problem is selected before starting an attempt.
- * - Sets the attempt's LeetCode ID and start time in the appropriate named ranges.
- * - Updates the UI to indicate an active attempt.
- * - TODO: Integrate live timer display.
- *
- * @returns {void}
- */
-function onStartClick() {
-    if (isAttemptInProgress()) {
-        SpreadsheetApp.getUi().alert('Attempt already in progress!');
-        return;
-    }
-    
-    let lcId;
-    try {
-        lcId = getCurrentProblemLcId();
-    } catch (e) {
-        SpreadsheetApp.getUi().alert('Select a problem first.');
-        return;
-    }
-    
-    // TODO: Dynamically show Attempt in Progress UI
-    updateAttemptInProgressUI(lcId);
-
-    // TODO: Show live timer
-}
-
-/**
  * Starts a problem attempt from the Group Selection view.
  *
  * Retrieves the problem attributes from the Group Selection control panel section  


### PR DESCRIPTION
## Related Issue
N/A

## Problem
The original implementation relied on Control Panel-based named ranges to manage the state of active problem attempts. With the addition of a dedicated Attempt In Progress UI sheet, workflows still depended on outdated Control Panel fields, creating inconsistencies in state management and blocking future features like progress tracking, capped time calculations, and dynamic optimal attempt inputs.

## Changes
- **Updated `NAMED_RANGES` and `SHEET_NAMES` constants**
  - Added new Attempt In Progress named ranges:
    - `DIFFICULTY`
    - `DOMINANT_TOPIC`
    - `END_TIME`
    - `INPUTS`
    - `OPTIMAL_INPUTS`
    - `PROBLEM_ATTRIBUTES`
    - `PROGRESS`
    - `START_TIME`
  - Added `ATTEMPTS` to `SHEET_NAMES`

- **Refactored `startWorkflow.js`**
  - Removed deprecated `onStartClick`
  - Replaced legacy Control Panel start workflow logic with a `startWorkflow` function using the new Attempt In Progress UI ranges
  - Updated `updateAttemptInProgressUI` to populate Attempt In Progress problem attributes and start time

- **Refactored `endWorkflow.js`**
  - Updated to write `END_TIME` to `NAMED_RANGES.AttemptInProgress.END_TIME` instead of legacy Control Panel range

- **Refactored `logWorkflow.js`**
  - Updated logging workflow to:
    - Read inputs from `NAMED_RANGES.AttemptInProgress.INPUTS`
    - Append rows to `SHEET_NAMES.ATTEMPTS`
    - Use new dynamic default values for duration and cap minutes based on Attempt In Progress ranges
    - Reset Attempt In Progres
