### PR TITLE
feat: add workflow cancel handler to reset in-progress attempt inputs

### DIFF
--- a/src/cancelWorkflow.js
+++ b/src/cancelWorkflow.js
@@ -1,0 +1,16 @@
+const { resetAttemptInputs, isAttemptInProgress } = require("./workflowUtils");
+
+function onCancelClick() {
+    if (!isAttemptInProgress()) return;
+    
+    const ui = SpreadsheetApp.getUi();
+    const response = ui.alert(
+        'Confirmation',
+        'Are you sure you want to cancel logging this attempt?',
+        ui.ButtonSet.YES_NO
+    );
+
+    if (response == ui.Button.NO) return;
+
+    resetAttemptInputs();
+}

--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,7 +1,6 @@
 const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
 const { getInputValues } = require("./sheetUtils/getInputValues");
-const { resetInputValues } = require("./sheetUtils/resetInputValues");
-const { restartProblemSelection } = require("./workflowUtils");
+const { resetAttemptInputs, restartProblemSelection } = require("./workflowUtils");
 
 function onLogClick() {
     logAttempt();
@@ -20,36 +19,4 @@ function logAttempt() {
     const inputValues = getInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, requiredFields);
 
     appendRowToSheet(SHEET_NAMES.ATTEMPTS, inputValues);
-}
-
-function resetAttemptInputs() {
-    const clearFields = [
-        'LC ID',
-        'Start Time',
-        'End Time',
-        'Notes'
-    ]
-
-    const defaults = {
-        'Duration Minutes': `=if(
-            ${NAMED_RANGES.AttemptInProgress.END_TIME}="","",
-            (${NAMED_RANGES.AttemptInProgress.END_TIME}-${NAMED_RANGES.AttemptInProgress.START_TIME})*1440
-            )`,
-        'Cap Minutes': `=iferror(index(
-            ${NAMED_RANGES.TargetTimes.MAX_MINUTES},
-            match(
-                ${NAMED_RANGES.AttemptInProgress.DOMINANT_TOPIC}&${NAMED_RANGES.AttemptInProgress.DIFFICULTY},
-                ${NAMED_RANGES.TargetTimes.TOPIC}&${NAMED_RANGES.TargetTimes.DIFFICULTY},
-                0
-            ),
-            1
-        ),"")`,
-        'Solved': false,
-        'Time Complexity Optimal': false,
-        'Space Complexity Optimal': false,
-        'Quality Code': false,
-    }
-
-    resetInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, defaults, clearFields);
-    resetInputValues(NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES);
 }

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -169,6 +169,49 @@ function isAttemptDone() {
     return getNamedRangeValue(NAMED_RANGES.AttemptInProgress.END_TIME) != '';
 }
 
+/**
+ * Resets the Attempt In Progress UI input fields to their default state.
+ *
+ * - Clears specified fields (`Start Time`, `End Time`, `Notes`) from the Attempt In Progress inputs.
+ * - Sets default values for calculated fields:
+ *   - `Duration Minutes` is set as the difference between `END_TIME` and `START_TIME` in minutes.
+ *   - `Cap Minutes` is dynamically calculated based on the selected dominant topic and difficulty.
+ *   - Boolean fields (`Solved`, `Time Complexity Optimal`, `Space Complexity Optimal`, `Quality Code`) are reset to `false`.
+ * - Resets all problem attribute fields in the Attempt In Progress section.
+ *
+ * @returns {void}
+ */
+function resetAttemptInputs() {
+    const clearFields = [
+        'Start Time',
+        'End Time',
+        'Notes'
+    ]
+
+    const defaults = {
+        'Duration Minutes': `=if(
+            ${NAMED_RANGES.AttemptInProgress.END_TIME}="","",
+            (${NAMED_RANGES.AttemptInProgress.END_TIME}-${NAMED_RANGES.AttemptInProgress.START_TIME})*1440
+            )`,
+        'Cap Minutes': `=iferror(index(
+            ${NAMED_RANGES.TargetTimes.MAX_MINUTES},
+            match(
+                ${NAMED_RANGES.AttemptInProgress.DOMINANT_TOPIC}&${NAMED_RANGES.AttemptInProgress.DIFFICULTY},
+                ${NAMED_RANGES.TargetTimes.TOPIC}&${NAMED_RANGES.TargetTimes.DIFFICULTY},
+                0
+            ),
+            1
+        ),"")`,
+        'Solved': false,
+        'Time Complexity Optimal': false,
+        'Space Complexity Optimal': false,
+        'Quality Code': false,
+    }
+
+    resetInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, defaults, clearFields);
+    resetInputValues(NAMED_RANGES.AttemptInProgress.PROBLEM_ATTRIBUTES);
+}
+
 module.exports = {
     clearCurrentProblem,
     updateSelectionMetrics,
@@ -177,5 +220,6 @@ module.exports = {
     getCurrentProblemLcId,
     isAttemptInProgress,
     isAttemptDone,
+    resetAttemptInputs,
     restartProblemSelection
 }


### PR DESCRIPTION
## Related Issue:
N/A

## Problem:
The current workflow lacked a way to safely cancel an in-progress attempt before logging it. If a user accidentally started an attempt or needed to step away, there was no clean, user-confirmed method to clear out the attempt’s input fields and reset the state.

## Changes:
- Added `onCancelClick` handler to `cancelWorkflow.js`:
  - Prompts the user with a confirmation dialog.
  - If confirmed, resets attempt inputs via `resetAttemptInputs`.
- Removed duplicated `resetAttemptInputs` implementation from `logWorkflow.js`.
- Centralized `resetAttemptInputs` utility in `workflowUtils.js`.

## Testing:
- Verified canceling a started attempt triggers confirmation dialog.
- Confirming cancellation clears Attempt In Progress inputs and problem attributes.
- Verified old logging flow continues to function after removal of duplicated code.

## Value:
Provides a safe, consistent way for users to abandon in-progress attempts without leaving residual data in the UI. Keeps workflow state reliable and improves operational UX flexibility.
