### PR TITLE
fix: Workflow bugs

### DIFF
--- a/src/findWorkflow.js
+++ b/src/findWorkflow.js
@@ -1,4 +1,5 @@
 const { NAMED_RANGES, MODEL_FIELD_MAPPINGS } = require("./constants");
+const { getLatestAttemptsMap } = require("./dataModelUtils/getLatestAttemptsMap");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
 const { getModelDataFromSheet } = require("./sheetUtils/getModelDataFromSheet");
 const { convertArrayToObject } = require("./utils/convertArrayToObject");
@@ -21,6 +22,7 @@ function onFindClick() {
             NAMED_RANGES.SingleSelection.TIME_SINCE
         );
         SpreadsheetApp.getUi().alert(e.message);
+        return;
     }
 
     updateCurrentProblem(
@@ -43,5 +45,11 @@ function findProblem() {
     if (!matches.length) throw new Error('No problem matches search criteria.');
     if (matches.length > 2) throw new Error('Multiple problems matching criteria.');
 
-    return convertArrayToObject(...matches);
+    const problemAttributes = convertArrayToObject(...matches);
+    const latestAttemptsMap = getLatestAttemptsMap();
+    if (latestAttemptsMap.hasOwnProperty(problemAttributes.lcId)) {
+        Object.assign(problemAttributes, latestAttemptsMap[problemAttributes.lcId]);
+    }
+
+    return problemAttributes;
 }

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -131,21 +131,6 @@ function updateSelectionMetrics(problemAttempts) {
 }
 
 /**
- * Retrieves the current problem's LeetCode ID from the named range.
- * 
- * @throws {Error} If no LC ID is found in the named range.
- * @returns {string} The LeetCode ID of the currently selected problem.
- */
-function getCurrentProblemLcId(rangeName) {
-    const lcId = getNamedRangeValue(rangeName);
-    if (!lcId) {
-        throw new Error('Missing LC ID.');
-    }
-
-    return lcId;
-}
-
-/**
  * Checks whether a LeetLogger problem attempt is currently in progress.
  *
  * This is determined by checking if the progress value named range
@@ -154,7 +139,7 @@ function getCurrentProblemLcId(rangeName) {
  * @returns {boolean} True if an attempt is in progress, false otherwise.
  */
 function isAttemptInProgress() {
-    return getNamedRangeValue(NAMED_RANGES.AttemptInProgress.PROGRESS) != '';
+    return getNamedRangeValue(NAMED_RANGES.AttemptInProgress.START_TIME) != '';
 }
 
 /**
@@ -217,7 +202,6 @@ module.exports = {
     updateSelectionMetrics,
     updateCurrentProblem,
     updateSkipCount,
-    getCurrentProblemLcId,
     isAttemptInProgress,
     isAttemptDone,
     resetAttemptInputs,


### PR DESCRIPTION
## Problem
A few bugs were uncovered in the workflows. `isAttemptInProgress` was checking the progress named range to determine if an attempt was in progress but this allows overwrites if an attempt is done but not yet logged. The find problem workflow was not retrieving the problems latest attempt data.

## Changes
- Change `isAttemptInProgress` to check `START_TIME` which only gets cleared after an attempt has been logged or canceled. 
- Use the latest attempts map to get latest attempt when searching for a problem.