### PR TITLE
refactor: centralize problem selector handling and standardize attempt UI transitions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,7 @@ const NAMED_RANGES = {
         DIFFICULTY: 'AttemptInprogress_Difficulty',
         DOMINANT_TOPIC: 'AttemptInProgress_DominantTopic',
         END_TIME: 'AttemptInProgress_EndTime',
+        INITIATOR: 'AttemptInProgress_Initiator',
         INPUTS: 'AttemptInProgress_AttemptInputs',
         OPTIMAL_INPUTS: 'AttemptInProgress_OptimalInputs',
         PROBLEM_ATTRIBUTES: 'AttemptInProgress_ProblemAttributes',
@@ -80,13 +81,18 @@ const NAMED_RANGES = {
         LATEST_ATTEMPT_ATTRIBUTES: 'SingleSelection_LatestAttemptAttributes',
         PROBLEM_ATTRIBUTES: 'SingleSelection_ProblemAttributes',
         PROBLEM_SEARCH_INPUTS: 'SingleSelection_ProblemSearchInputs',
-        TIME_SINCE: 'SingleSelection_TimeSince',
+        TIME_SINCE_CURRENT_PROBLEM: 'SingleSelection_TimeSince',
     },
     TargetTimes: {
         DIFFICULTY: 'TargetTimesDifficulty',
         MAX_MINUTES: 'TargetTimesMaxMinutes',
         TOPIC: 'TargetTimesTopic'
     }
+}
+
+const PROBLEM_SELECTORS = {
+    GROUP_SELECTION: 'GroupSelection',
+    SINGLE_SELECTION: 'SingleSelection',
 }
 
 const SHEET_NAMES = {
@@ -98,5 +104,6 @@ module.exports = {
     DOMINANT_TOPICS,
     MODEL_FIELD_MAPPINGS,
     NAMED_RANGES,
+    PROBLEM_SELECTORS,
     SHEET_NAMES,
  }

--- a/src/findWorkflow.js
+++ b/src/findWorkflow.js
@@ -1,4 +1,4 @@
-const { NAMED_RANGES, MODEL_FIELD_MAPPINGS } = require("./constants");
+const { NAMED_RANGES, MODEL_FIELD_MAPPINGS, PROBLEM_SELECTORS } = require("./constants");
 const { getLatestAttemptsMap } = require("./dataModelUtils/getLatestAttemptsMap");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
 const { getModelDataFromSheet } = require("./sheetUtils/getModelDataFromSheet");
@@ -16,21 +16,12 @@ function onFindClick() {
     try {
         problem = findProblem();
     } catch (e) {
-        clearCurrentProblem(
-            NAMED_RANGES.SingleSelection.PROBLEM_ATTRIBUTES,
-            NAMED_RANGES.SingleSelection.LATEST_ATTEMPT_ATTRIBUTES,
-            NAMED_RANGES.SingleSelection.TIME_SINCE
-        );
+        clearCurrentProblem(PROBLEM_SELECTORS.SINGLE_SELECTION);
         SpreadsheetApp.getUi().alert(e.message);
         return;
     }
 
-    updateCurrentProblem(
-        problem,
-        NAMED_RANGES.SingleSelection.PROBLEM_ATTRIBUTES,
-        NAMED_RANGES.SingleSelection.LATEST_ATTEMPT_ATTRIBUTES,
-        NAMED_RANGES.SingleSelection.TIME_SINCE
-    )
+    updateCurrentProblem(problem, PROBLEM_SELECTORS.SINGLE_SELECTION)
 }
 
 function findProblem() {

--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,6 +1,7 @@
-const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
+const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
 const { getInputValues } = require("./sheetUtils/getInputValues");
-const { resetAttemptInputs, restartProblemSelection } = require("./workflowUtils");
+const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
+const { resetAttemptInputs, restartProblemSelection, clearCurrentProblem } = require("./workflowUtils");
 
 function onLogClick() {
     logAttempt();
@@ -19,4 +20,14 @@ function logAttempt() {
     const inputValues = getInputValues(NAMED_RANGES.AttemptInProgress.INPUTS, requiredFields);
 
     appendRowToSheet(SHEET_NAMES.ATTEMPTS, inputValues);
+
+    const attemptInitiator = getNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR);
+    try {
+        SpreadsheetApp.getActiveSpreadsheet().getSheetByName(attemptInitiator).activate();
+    } catch (e) {
+        return;
+    }
+    if (attemptInitiator == PROBLEM_SELECTORS.SINGLE_SELECTION) {
+        clearCurrentProblem(PROBLEM_SELECTORS.SINGLE_SELECTION);
+    }
 }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -1,4 +1,4 @@
-const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
+const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
 const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
@@ -13,7 +13,7 @@ const { isAttemptInProgress } = require("./workflowUtils");
  * @returns {void}
  */
 function onGroupSelectionStartClick() {
-    startWorkflow(NAMED_RANGES.GroupSelection.PROBLEM_ATTRIBUTES);
+    startWorkflow(NAMED_RANGES.GroupSelection.PROBLEM_ATTRIBUTES, PROBLEM_SELECTORS.GROUP_SELECTION);
 }
 
 /**
@@ -25,7 +25,7 @@ function onGroupSelectionStartClick() {
  * @returns {void}
  */
 function onSingleSelectionStartClick() {
-    startWorkflow(NAMED_RANGES.SingleSelection.PROBLEM_ATTRIBUTES);
+    startWorkflow(NAMED_RANGES.SingleSelection.PROBLEM_ATTRIBUTES, PROBLEM_SELECTORS.SINGLE_SELECTION);
 }
 
 /**
@@ -39,7 +39,7 @@ function onSingleSelectionStartClick() {
  * @param {string} problemAttributesRangeName - The named range for the problem attributes section in the UI.
  * @returns {void}
  */
-function startWorkflow(problemAttributesRangeName) {
+function startWorkflow(problemAttributesRangeName, initiator) {
     if (isAttemptInProgress()) {
         SpreadsheetApp.getUi().alert('Attempt already in progress!');
         return;
@@ -53,6 +53,7 @@ function startWorkflow(problemAttributesRangeName) {
     
     SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS).activate();
     updateAttemptInProgressUI(problemAttributes);
+    setNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR, initiator);
 }
 
 /**


### PR DESCRIPTION
## Related Issue  
N/A — infrastructure improvement for problem selection workflows.

## Problem  
The current implementation for logging problem attempts lacked a mechanism to automatically switch back to the originating problem selection UI after an attempt was logged. Additionally, the `updateCurrentProblem` and `clearCurrentProblem` utilities relied on explicitly passing individual named ranges, limiting scalability and making it cumbersome to extend support for new selection workflows (e.g. randomized selection or category-based pickers).

## Changes  
- Added a new `PROBLEM_SELECTORS` constant mapping selector keys to their associated named ranges in `NAMED_RANGES`.
- Modified `updateCurrentProblem` and `clearCurrentProblem` to accept a `problemSelector` key instead of individual range names.
- Refactored `onFindClick`, `restartProblemSelection`, and `onLogClick` to use `PROBLEM_SELECTORS` when invoking these utilities.
- Updated `startWorkflow` to accept an `initiator` argument and save it via the `AttemptInProgress.INITIATOR` named range.
- Enhanced `onGroupSelectionStartClick` and `onSingleSelectionStartClick` to pass the appropriate problem selector as initiator.
- Updated `NAMED_RANGES.SingleSelection` to replace `TIME_SINCE` with `TIME_SINCE_CURRENT_PROBLEM` for consistency.
- Cleaned up redundant multi-param function calls now unified under the selector-based system.

## Testing  
- Manually verified starting an attempt from both Group Selection and Single Selection correctly sets the `INITIATOR` range.
- Confirmed logging an attempt switches the active sheet back to the originating problem selection UI.
- Confirmed that in Group Selection, the next problem replaces the current one, and in Single Selection, the problem details are cleared after logging.
- Verified no regressions in updating or clearing problem details in either workflow.

## Value  
This refactor improves the scalability and maintainability of the problem selection and logging workflows by:
- Centralizing selector-specific range references.
- Reducing coupling between utility functions and UI implementation details.
- Enabling seamless future support for additional selection workflows (e.g. randomized pickers, topic-only selectors) without modifying core utilities.
- Improving UX consistency by ensuring the UI reliably returns to the correct context after an attempt is logged.
