### PR TITLE
fix: redirect UI to initiating problem selector on workflow cancellation

### DIFF
--- a/src/cancelWorkflow.js
+++ b/src/cancelWorkflow.js
@@ -13,4 +13,11 @@ function onCancelClick() {
     if (response == ui.Button.NO) return;
 
     resetAttemptInputs();
+    
+    const attemptInitiator = getNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR);
+    try {
+        SpreadsheetApp.getActiveSpreadsheet().getSheetByName(attemptInitiator).activate();
+    } catch (e) {
+        return;
+    }
 }


### PR DESCRIPTION
## Related Issue  
N/A

## Problem  
When an attempt was canceled, the UI remained on the `AttemptInProgress` sheet, leaving the user in an irrelevant context instead of returning them to the problem selector that initiated the attempt.

## Changes  
- Retrieved the initiating problem selector sheet name from the `NAMED_RANGES.AttemptInProgress.INITIATOR` named range.
- Attempted to activate the initiating sheet after cancelling the workflow.
- Gracefully handled the case where the initiating sheet no longer exists by wrapping in a try/catch.

## Testing  
Manually tested:
- Canceling an in-progress attempt returns the user to the correct initiating problem selector sheet.
- No errors thrown if the initiating sheet has been deleted.

## Value  
Ensures a consistent, intuitive workflow by returning the user to the relevant UI context after cancelling an in-progress attempt.
