### PR TITLE
feat: Implement handler for adding a new problem to the list

### DIFF
--- a/src/addWorkflow.js
+++ b/src/addWorkflow.js
@@ -1,0 +1,40 @@
+const { NAMED_RANGES, SHEET_NAMES } = require("./constants");
+const { appendRowToSheet } = require("./sheetUtils/appendRowToSheet");
+const { getInputValues } = require("./sheetUtils/getInputValues");
+const { resetInputValues } = require("./sheetUtils/resetInputValues");
+
+function onAddClick() {
+    logProblem();
+    resetProblemInputs();
+}
+
+function logProblem() {
+    const requiredFields = [
+        'LC ID',
+        'Dominant Topic',
+        'Difficulty',
+        'Input Data Structure',
+        'Name',
+        'Link',
+    ]
+    const inputValues = getInputValues(NAMED_RANGES.AddProblem.INPUTS, requiredFields);
+    appendRowToSheet(SHEET_NAMES.PROBLEMS, inputValues);
+}
+
+function resetProblemInputs() {
+    const clearFields = [
+        'LC ID',
+        'Subdominant Topic',
+        'Input Data Structure',
+        'Name',
+        'Link',
+        'Optimal Solution',
+    ]
+
+    const defaults = {
+        'Deleted': false,
+        'Premium': false,
+    }
+
+    resetInputValues(NAMED_RANGES.AddProblem.INPUTS, defaults, clearFields);
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,9 @@ const MODEL_FIELD_MAPPINGS = {
 }
 
 const NAMED_RANGES = {
+    AddProblem: {
+        INPUTS: 'AddProblem_Inputs',
+    },
     AttemptInProgress: {
         DIFFICULTY: 'AttemptInprogress_Difficulty',
         DOMINANT_TOPIC: 'AttemptInProgress_DominantTopic',
@@ -93,6 +96,7 @@ const PROBLEM_SELECTORS = {
 const SHEET_NAMES = {
     ATTEMPTS: 'Attempts',
     ATTEMPT_IN_PROGRESS: 'AttemptInProgress',
+    PROBLEMS: 'Problems',
 }
 
 module.exports = {

--- a/src/sheetUtils/appendRowToSheet.js
+++ b/src/sheetUtils/appendRowToSheet.js
@@ -15,3 +15,5 @@ function appendRowToSheet(sheetName, rowValues) {
     
     sheet.appendRow(rowValues);
 }
+
+module.exports = { appendRowToSheet }


### PR DESCRIPTION
## Related Issue
_No issue linked_

## Problem
Previously, there was no streamlined way to add a new problem to the problem list sheet while ensuring that all required fields were provided and that optional values were reset consistently. This made it error-prone to manually input problems and increased friction in maintaining an accurate, normalized dataset.

## Changes
- Added `src/addWorkflow.js` containing:
  - `onAddClick` handler to trigger the add problem workflow
  - `logProblem` to capture and validate required problem fields via named ranges and append them to the problem list
  - `resetProblemInputs` to clear and reset relevant input fields after submission
- Extended `NAMED_RANGES` in `src/constants.js` to include:
  - `AddProblem.INPUTS`
- Added `PROBLEMS` to `SHEET_NAMES` in `src/constants.js`
- Updated `src/sheetUtils/appendRowToSheet.js` to export `appendRowToSheet` for use in the new workflow

## Testing
- Manually verified that adding a problem via input ranges appends a row with correct values to the `Problems` sheet.
- Confirmed that input values reset appropriately after submission.
- Validated behavior with missing required fields to ensure error handling.

## Value
This workflow simplifies and safeguards the process of adding new problems to the list by:
- Enforcing presence of required fields before submission
- Automatically resetting input fields to default states after logging
- Centralizing logic for data validation, sheet writing, and field resetting into reusable utilities
