### PR TITLE
feat: Track and Display Optimal Solution Links in Problem Workflow

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -43,6 +43,7 @@ const NAMED_RANGES = {
         FILTERS: 'GroupSelection_Filters',
         LATEST_ATTEMPT_ATTRIBUTES: 'GroupSelection_LatestAttemptAttributes',
         LC_ID: 'GroupSelection_LC_ID',
+        OPTIMAL_SOLUTION: 'GroupSelection_OptimalSolution',
         PRIORITIZE_NOT_QUALITY_CODE: 'GroupSelection_PrioritizeNotQualityCode',
         PRIORITIZE_SPACE_NOT_OPTIMAL: 'GroupSelection_PrioritizeSpaceNotOptimal',
         PRIORITIZE_TIME_NOT_OPTIMAL: 'GroupSelection_PrioritizeTimeNotOptimal',
@@ -69,6 +70,7 @@ const NAMED_RANGES = {
     },
     SingleSelection: {
         LATEST_ATTEMPT_ATTRIBUTES: 'SingleSelection_LatestAttemptAttributes',
+        OPTIMAL_SOLUTION: 'SingleSelection_OptimalSolution',
         PROBLEM_ATTRIBUTES: 'SingleSelection_ProblemAttributes',
         PROBLEM_SEARCH_INPUTS: 'SingleSelection_ProblemSearchInputs',
         TIME_SINCE_CURRENT_PROBLEM: 'SingleSelection_TimeSince',

--- a/src/workflowUtils.js
+++ b/src/workflowUtils.js
@@ -82,6 +82,8 @@ function updateCurrentProblem(problemAttemptAttributes, problemSelector) {
     } else {
         setNamedRangeValue(NAMED_RANGES[problemSelector].TIME_SINCE_CURRENT_PROBLEM, 'Unattempted');
     }
+
+    setNamedRangeValue(NAMED_RANGES[problemSelector].OPTIMAL_SOLUTION, problemAttemptAttributes.optimalSolution);
 }
 
 /**
@@ -100,6 +102,7 @@ function clearCurrentProblem(problemSelector) {
     resetInputValues(NAMED_RANGES[problemSelector].PROBLEM_ATTRIBUTES);
     resetInputValues(NAMED_RANGES[problemSelector].LATEST_ATTEMPT_ATTRIBUTES);
     setNamedRangeValue(NAMED_RANGES[problemSelector].TIME_SINCE_CURRENT_PROBLEM, '');
+    setNamedRangeValue(NAMED_RANGES[problemSelector].OPTIMAL_SOLUTION, '');
 }
 
 function updateSelectionMetrics(problemAttempts) {


### PR DESCRIPTION
## Related Issue
N/A

## Problem
There was no mechanism to persist or surface links to saved optimal solutions for individual problems within the workflow. This limited the ability to quickly reference previously reasoned, optimal approaches when reviewing or retrying problems.

## Changes
- Added `OPTIMAL_SOLUTION` named range for both `GroupSelection` and `SingleSelection` in `src/constants.js`.
- Updated `updateCurrentProblem` to set the `OPTIMAL_SOLUTION` named range with the value from `problemAttemptAttributes`.
- Updated `clearCurrentProblem` to reset the `OPTIMAL_SOLUTION` named range to an empty string.

## Testing
- Manually verified that when a problem is updated via `updateCurrentProblem`, the corresponding optimal solution link is written to the appropriate named range.
- Confirmed that clearing a problem via `clearCurrentProblem` resets the optimal solution value.

## Value
Enables users to persist and display links to optimal solution docs for each problem within the sheet UI, making high-quality reference material quickly accessible during problem reviews and reattempts.
