### PR TITLE
Auto-Manage AttemptInProgress Sheet Visibility to Track Unlogged Attempts

### DIFF
--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,6 +1,7 @@
 const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
 const { getInputValues } = require("./sheetUtils/getInputValues");
 const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
+const { getSheetByName } = require("./sheetUtils/getSheetByName");
 const { resetAttemptInputs, restartProblemSelection, clearCurrentProblem } = require("./workflowUtils");
 
 function onLogClick() {
@@ -30,4 +31,6 @@ function logAttempt() {
     if (attemptInitiator == PROBLEM_SELECTORS.SINGLE_SELECTION) {
         clearCurrentProblem(PROBLEM_SELECTORS.SINGLE_SELECTION);
     }
+
+    getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS).hideSheet();
 }

--- a/src/sheetUtils/getSheetByName.js
+++ b/src/sheetUtils/getSheetByName.js
@@ -1,0 +1,7 @@
+function getSheetByName(sheetName) {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+    if (!sheet) throw new Error(`Sheet "${sheetName}" not found`);
+    return sheet;
+}
+
+module.exports = { getSheetByName }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -1,5 +1,6 @@
 const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
+const { getSheetByName } = require("./sheetUtils/getSheetByName");
 const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
 const { isAttemptInProgress } = require("./workflowUtils");
@@ -50,8 +51,10 @@ function startWorkflow(problemAttributesRangeName, initiator) {
         SpreadsheetApp.getUi().alert('Select a problem first.');
         return;
     }
-    
-    SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS).activate();
+
+    const attemptInProgressSheet = getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS);
+    attemptInProgressSheet.showSheet();
+    attemptInProgressSheet.activate();
     updateAttemptInProgressUI(problemAttributes);
     setNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR, initiator);
 }


### PR DESCRIPTION
## Related Issue
N/A

## Problem
There was no automatic indication within the spreadsheet UI whether a problem attempt was currently in progress and unlogged when switching between sheets or tabs. This made it easy to lose track of ongoing attempts and risk forgetting to log them properly.

## Changes
- Added `getSheetByName` utility with error handling for missing sheets.
- Modified `startWorkflow` to show and activate the `AttemptInProgress` sheet immediately upon starting an attempt.
- Updated `logWorkflow` to hide the `AttemptInProgress` sheet after logging and clearing the current attempt.
- Ensured the UI visibility of `AttemptInProgress` sheet now accurately reflects whether an attempt is in progress, improving user awareness.

## Testing
- Verified that starting an attempt causes the `AttemptInProgress` sheet to become visible and active.
- Verified that logging an attempt hides the `AttemptInProgress` sheet.
- Verified that switching tabs or sheets correctly reflects attempt progress state through sheet visibility.

## Value
This change improves workflow clarity by making ongoing attempts visually obvious via sheet visibility, reducing the risk of unlogged work and improving user experience when navigating the spreadsheet tool.
