### PR TITLE
feat: display optimal solution link on attempt in progress UI

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ const NAMED_RANGES = {
         INITIATOR: 'AttemptInProgress_Initiator',
         INPUTS: 'AttemptInProgress_AttemptInputs',
         OPTIMAL_INPUTS: 'AttemptInProgress_OptimalInputs',
+        OPTIMAL_SOLUTION: 'AttemptInProgress_OptimalSolution',
         PROBLEM_ATTRIBUTES: 'AttemptInProgress_ProblemAttributes',
         PROGRESS: 'AttemptInProgress_Progress',
         START_TIME: 'AttemptInProgress_StartTime',

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -1,5 +1,6 @@
 const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
 const { getInputsFromSheetUI } = require("./sheetUtils/getInputsFromSheetUI");
+const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
 const { getSheetByName } = require("./sheetUtils/getSheetByName");
 const { setInputsOnSheetUI } = require("./sheetUtils/setInputsOnSheetUI");
 const { setNamedRangeValue } = require("./sheetUtils/setNamedRangeValue");
@@ -56,6 +57,8 @@ function startWorkflow(problemAttributesRangeName, initiator) {
     attemptInProgressSheet.showSheet();
     attemptInProgressSheet.activate();
     updateAttemptInProgressUI(problemAttributes);
+    const optimalSolution = getNamedRangeValue(NAMED_RANGES[initiator].OPTIMAL_SOLUTION);
+    setNamedRangeValue(NAMED_RANGES.AttemptInProgress.OPTIMAL_SOLUTION, optimalSolution);
     setNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR, initiator);
 }
 


### PR DESCRIPTION
## Related Issue
_No issue linked_

## Problem
The optimal solution link was available in the problem selector UIs but was not surfaced in the Attempt In Progress UI after initiating an attempt. This made it inconvenient to reference the optimal solution while working on an attempt, requiring unnecessary tab switching.

## Changes
- Added `OPTIMAL_SOLUTION` to the `NAMED_RANGES.AttemptInProgress` constant.
- Fetched the selected problem’s optimal solution link in `startWorkflow()`.
- Passed the optimal solution link to the Attempt In Progress UI by setting the corresponding named range value.

## Testing
- Verified that the optimal solution link is correctly displayed in the Attempt In Progress UI after starting an attempt via both group and single problem selection.
- Confirmed no regressions in existing workflow behavior.

## Value
Improves usability by making the optimal solution reference readily accessible during an attempt, eliminating the need to switch tabs or navigate back to the selector UI.
