### PR TITLE
feat: add topic + input structure metrics view for granular weak area analysis

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -89,11 +89,21 @@ const NAMED_RANGES = {
     },
     TopicMetrics: {
         EXCLUDE_DOMINANT_TOPICS: 'TopicMetrics_ExcludeDominantTopics',
-        TOP_N: 'TopMetrics_TopN',
-        TOPIC_METRICS: 'TopicMetrics_TopicMetrics',
+        TOP_N: 'TopicMetrics_TopN',
+        MIN_TOTAL_ATTEMPTS: 'TopicMetrics_MinTotalAttempts',
+        METRICS: 'TopicMetrics_TopicMetrics',
         PROBLEM_FILTERS: 'TopicMetrics_ProblemFilters',
         SORT_METRIC: 'TopicMetrics_SortMetric',
         TIMEFRAME: 'TopicMetrics_Timeframe',
+    },
+    TopicStructureMetrics: {
+        EXCLUDE_DOMINANT_TOPICS: 'TopicStructureMetrics_ExcludeDominantTopics',
+        TOP_N: 'TopicStructureMetrics_TopN',
+        MIN_TOTAL_ATTEMPTS: 'TopicStructureMetrics_MinTotalAttempts',
+        METRICS: 'TopicStructureMetrics_TopicStructureMetrics',
+        PROBLEM_FILTERS: 'TopicStructureMetrics_ProblemFilters',
+        SORT_METRIC: 'TopicStructureMetrics_SortMetric',
+        TIMEFRAME: 'TopicStructureMetrics_Timeframe',
     }
 }
 
@@ -106,6 +116,8 @@ const SHEET_NAMES = {
     ATTEMPTS: 'Attempts',
     ATTEMPT_IN_PROGRESS: 'AttemptInProgress',
     PROBLEMS: 'Problems',
+    TOPIC_METRICS: 'TopicMetrics',
+    TOPIC_STRUCTURE_METRICS: 'TopicStructureMetrics',
 }
 
 module.exports = {

--- a/src/sheetUtils/getNamedRange.js
+++ b/src/sheetUtils/getNamedRange.js
@@ -6,6 +6,7 @@
  * @throws {Error} If the named range is not found.
  */
 function getNamedRange(rangeName) {
+    if (!rangeName) throw new Error('Range name required!');
     const range = SpreadsheetApp.getActiveSpreadsheet().getRangeByName(rangeName);
     if (!range) {
         throw new Error(`Named range "${rangeName}" not found.`);


### PR DESCRIPTION
## Problem
The existing "Topic Metrics" view summarizes performance by dominant topic (e.g., DFS, Two-Pointer), which works well for identifying high-level weak areas. However, this abstraction can obscure more specific struggles tied to particular input data structures (e.g., DFS on graphs vs binary trees). This is especially problematic for patterns like DFS where the underlying structure significantly affects problem-solving approach and difficulty.

## Changes
- Introduced a new `TopicStructureMetrics` view to independently summarize and rank performance by both `dominantTopic` and `inputDataStructure`.
- Added a new `SHEET_NAME` entry for `TopicStructureMetrics`.
- Defined corresponding `NAMED_RANGES` constants for storing UI filters and summary output.
- Refactored metrics logic into a shared `metricsWorkflow` function parameterized by:
  - `sheetName` to support multiple views.
  - `keyFields` to summarize by either one or multiple fields.
  - `includeAllOther` to conditionally group non-top-N entries.
- Added helper `summarizeMetricsByCustomKey` to support key generation via arbitrary field combinations.
- Added `onTopicStructureMetricsUpdateClick` entry point to trigger the new workflow.

## Testing
- Verified that both TopicMetrics and TopicStructureMetrics run independently and correctly reflect their respective UI filters and sort settings.
- Confirmed that the new view handles granular combinations like DFS+Matrix or DFS+BST without affecting the existing TopicMetrics logic.

## Value
This change allows for more accurate identification of weakness patterns, particularly in cases where the same topic behaves very differently across input structures. The new view ensures these differences are surfaced and not masked by high overall performance in broader topic categories.
