### PR TITLE
feat: add support for multi-select dropdown values in problem filtering

### DIFF
--- a/src/dataModelUtils/getFilteredProblems.js
+++ b/src/dataModelUtils/getFilteredProblems.js
@@ -22,7 +22,7 @@ function getFilteredProblems(filtersRangeName) {
 
     const criteria = [{ field: 'deleted', value: false, mode: 'equals' }];
     for (const [field, value] of filters) {
-        if (value != 'All') {
+        if (!value.includes('All')) {
             criteria.push({
                 field: MODEL_FIELD_MAPPINGS.Problem[field],
                 value: value,

--- a/src/utils/filter2DArrayRows.js
+++ b/src/utils/filter2DArrayRows.js
@@ -27,12 +27,15 @@ function filter2DArrayRows(data, criteria) {
     const filtered = data.slice(1).filter(row =>
       criteria.every(({ field, value, mode }) => {
         const cellValue = row[headerIndices[field]]?.toString().toLowerCase();
-        const searchValue = value.toString().toLowerCase();
+
+        const values = typeof value === 'string' && value.includes(',')
+          ? value.split(',').map(v => v.trim().toLowerCase())
+          : [value.toString().toLowerCase()];
 
         if (mode === 'equals') {
-          return cellValue === searchValue;
+          return values.some(val => cellValue === val);
         } else if (mode === 'includes') {
-          return cellValue.includes(searchValue);
+          return values.some(val => cellValue.includes(val));
         }
 
         return false;

--- a/tests/utils/filter2DArrayRows.test.js
+++ b/tests/utils/filter2DArrayRows.test.js
@@ -13,7 +13,7 @@ describe('filter2DArrayRows', () => {
     expect(result).toEqual([
       ['LC ID', 'Dominant Topic', 'Difficulty'],
       [1, 'Two-Pointer', 'Easy'],
-    ])
+    ]);
   });
 
   it('filters with includes', () => {
@@ -23,7 +23,7 @@ describe('filter2DArrayRows', () => {
       ['LC ID', 'Dominant Topic', 'Difficulty'],
       [1, 'Two-Pointer', 'Easy'],
       [2, 'Two-Pointer', 'Medium'],
-    ])
+    ]);
   });
 
   it('filters with multiple criteria', () => {
@@ -35,7 +35,7 @@ describe('filter2DArrayRows', () => {
     expect(result).toEqual([
       ['LC ID', 'Dominant Topic', 'Difficulty'],
       [1, 'Two-Pointer', 'Easy'],
-    ])
+    ]);
   });
 
   it('handles case-insensitive matches', () => {
@@ -64,5 +64,25 @@ describe('filter2DArrayRows', () => {
     expect(() => {
       filter2DArrayRows(invalidData, criteria);
     }).toThrow("Required column 'Dominant Topic' is missing from the data.");
+  });
+
+  it('filters with multi-select equals', () => {
+    const criteria = [{field: 'Difficulty', value: 'Easy, Medium', mode: 'equals'}];
+    const result = filter2DArrayRows(dummyData, criteria);
+    expect(result).toEqual([
+      ['LC ID', 'Dominant Topic', 'Difficulty'],
+      [1, 'Two-Pointer', 'Easy'],
+      [2, 'Two-Pointer', 'Medium'],
+    ]);
+  });
+
+  it('filters with multi-select includes', () => {
+    const criteria = [{field: 'Difficulty', value: 'Eas, Med', mode: 'includes'}];
+    const result = filter2DArrayRows(dummyData, criteria);
+    expect(result).toEqual([
+      ['LC ID', 'Dominant Topic', 'Difficulty'],
+      [1, 'Two-Pointer', 'Easy'],
+      [2, 'Two-Pointer', 'Medium'],
+    ]);
   });
 });


### PR DESCRIPTION
**Problem:**  
The current filtering logic only supports single-value selections in dropdown filters. However, Google Sheets multi-select dropdowns return values as a comma-separated string (e.g. `"Easy, Medium"`), and our centralized filtering logic did not previously handle this format. Additionally, there was no built-in "All" option support in Google Sheets, requiring manual logic to treat "All" as a no-op in filtering.

**Changes:**  
- Updated `filter2DArrayRows` to:
  - Detect comma-separated `value` strings and normalize them to arrays internally.
  - Apply the filtering logic using `Array.prototype.some` to support multiple values with both `equals` and `includes` modes.
  - Preserve existing behavior for single-value filters.
- Updated `getFilteredProblems` to skip filters if any selection includes `"All"`.
- Added test coverage for multi-select `equals` and `includes` scenarios in `filter2DArrayRows.test.js`.

**Testing:**  
- Added unit tests covering:
  - Multi-select with `equals` mode (`'Easy, Medium'`)
  - Multi-select with `includes` mode (`'Eas, Med'`)
- All existing tests pass.

**Value:**  
This change enables UI components using Google Sheets multi-select dropdowns to work seamlessly with the existing filtering mechanism without requiring special-case logic in each caller. It ensures centralized, reusable multi-value support for future filtering use cases.
