### PR TITLE
feat: Add ListSelection handlers and problem selection logic

### DIFF
--- a/src/Selection/ListSelection/ListSelectionHandlers.js
+++ b/src/Selection/ListSelection/ListSelectionHandlers.js
@@ -1,0 +1,60 @@
+const { getLatestAttemptsMap } = require("../../dataModelUtils/getLatestAttemptsMap");
+const { ProblemNotFoundError, NoMoreProblemsError } = require("../../errors");
+const { convertArrayToObject } = require("../../utils/convertArrayToObject");
+const { filter2DArrayRows } = require("../../utils/filter2DArrayRows");
+const { getFirstProblem, getNextProblem } = require("./ListSelectionLogic");
+
+function onRestartClick() {
+    handleListSelection(getFirstProblem);
+}
+
+function onNextClick() {
+    handleListSelection(getNextProblem);
+}
+
+function handleListSelection(selectFn) {
+    const ui = SpreadsheetApp.getUi();
+    if (isAttemptInProgress()) {
+        ui.alert('Attempt currently in progress!');
+        return;
+    }
+
+    clearCurrentProblem(PROBLEM_SELECTORS.LIST_SELECTION);
+
+    const listName = getNamedRangeValue(NAMED_RANGES.ListSelection.LIST);
+    const orderedList = getOrderedList(listName);
+    const problems = getModelDataFromSheet('Problem');
+
+    const latestAttemptsMap = getLatestAttemptsMap();
+
+    let nextProblem;
+    try {
+        nextProblem = selectFn(orderedList, problems, latestAttemptsMap);
+    } catch(e) {
+        if (e instanceof ProblemNotFoundError) {
+            ui.alert(`${e.message} Either add it using AddProblem or set Skip = true in ${listName}.`);
+            return;
+        } else if (e instanceof NoMoreProblemsError) {
+            const response = ui.alert(
+                'Restart?',
+                'All problems in list have been attempted, would you like to restart the list?',
+                ui.ButtonSet.YES_NO
+            );
+            if (response === ui.Button.NO) return;
+            nextProblem = getFirstProblem(orderedList, problems);
+        } else {
+            ui.alert(e.message);
+        }
+    }
+
+    const problemAttemptAtributes = Object.assign(nextProblem, latestAttemptsMap[nextProblem.lcId]);
+    updateCurrentProblem(problemAttemptAtributes, PROBLEM_SELECTORS.LIST_SELECTION);
+}
+
+function getOrderedList(listName) {
+    const data = getSheetByName(listName).getDataRange().getValues();
+    
+    return filter2DArrayRows(data, [{ field: 'Skip', value: false, mode: 'equals' }]);
+}
+
+module.exports = { handleListSelection }

--- a/src/Selection/ListSelection/ListSelectionHandlers.js
+++ b/src/Selection/ListSelection/ListSelectionHandlers.js
@@ -34,7 +34,8 @@ function handleListSelection(selectFn) {
         if (e instanceof ProblemNotFoundError) {
             ui.alert(`${e.message} Either add it using AddProblem or set Skip = true in ${listName}.`);
             return;
-        } else if (e instanceof NoMoreProblemsError) {
+        }
+        if (e instanceof NoMoreProblemsError) {
             const response = ui.alert(
                 'Restart?',
                 'All problems in list have been attempted, would you like to restart the list?',

--- a/src/Selection/ListSelection/ListSelectionHandlers.js
+++ b/src/Selection/ListSelection/ListSelectionHandlers.js
@@ -12,6 +12,16 @@ function onNextClick() {
     handleListSelection(getNextProblem);
 }
 
+/**
+ * Core handler that manages problem selection flow.
+ *
+ * Validates attempt state, retrieves relevant list data,
+ * and delegates problem selection logic to the provided selector function.
+ *
+ * @param {(orderedList: any[][], problems: any[][], latestAttemptsMap: Object) => Object} selectFn
+ *        The function to determine the next problem (e.g., getNextProblem or getFirstProblem).
+ * @returns {void}
+ */
 function handleListSelection(selectFn) {
     const ui = SpreadsheetApp.getUi();
     if (isAttemptInProgress()) {
@@ -52,6 +62,13 @@ function handleListSelection(selectFn) {
     updateCurrentProblem(problemAttemptAtributes, PROBLEM_SELECTORS.LIST_SELECTION);
 }
 
+/**
+ * Retrieves the ordered list of problems for the given list name.
+ * Filters out rows marked as "Skip".
+ *
+ * @param {string} listName - The name of the list sheet.
+ * @returns {any[][]} The filtered list of problems.
+ */
 function getOrderedList(listName) {
     const data = getSheetByName(listName).getDataRange().getValues();
     

--- a/src/Selection/ListSelection/ListSelectionLogic.js
+++ b/src/Selection/ListSelection/ListSelectionLogic.js
@@ -22,7 +22,7 @@ function getNextProblem(orderedList, problems, latestAttemptsMap) {
 
     for (let i = 1; i < orderedList.length; i++) {
         const name = orderedList[i][1];
-        const problem = problemsMap[orderedList[i][1]];
+        const problem = problemsMap[name];
         if (!problem) throw new Error(`Problem ${name} not found`);
 
         const latestAttempt = latestAttemptsMap[problem.lcId];

--- a/src/Selection/ListSelection/ListSelectionLogic.js
+++ b/src/Selection/ListSelection/ListSelectionLogic.js
@@ -2,6 +2,14 @@ const { NoMoreProblemsError, ProblemNotFoundError } = require("../../errors");
 const { convert2DArrayToObjects } = require("../../utils/convert2DArrayToObjects");
 const { convertArrayToObject } = require("../../utils/convertArrayToObject");
 
+/**
+ * Retrieves the first problem in the given ordered list.
+ *
+ * @param {any[][]} orderedList - The ordered list of problems (including headers).
+ * @param {any[][]} problems - The raw problem data from the "Problem" sheet.
+ * @throws {ProblemNotFoundError} If the first problem cannot be found in the dataset.
+ * @returns {Object} The first problem object.
+ */
 function getFirstProblem(orderedList, problems) {
     const problemName = orderedList[1][1];
     const matches = filter2DArrayRows(problems, [{ field: 'name', value: problemName, mode: 'equals' }]);
@@ -13,6 +21,18 @@ function getFirstProblem(orderedList, problems) {
     return convertArrayToObject(problems[0], matches[1]);
 }
 
+/**
+ * Determines the next problem to attempt in the list.
+ * Selects the first problem that has not been attempted more recently
+ * than its predecessor.
+ *
+ * @param {any[][]} orderedList - The ordered list of problems (including headers).
+ * @param {any[][]} problems - The raw problem data from the "Problem" sheet.
+ * @param {Object.<string, Object>} latestAttemptsMap - Map of problem lcIds to their latest attempt data.
+ * @throws {ProblemNotFoundError} If a problem in the list cannot be found.
+ * @throws {NoMoreProblemsError} If all problems have already been attempted.
+ * @returns {Object} The next problem object.
+ */
 function getNextProblem(orderedList, problems, latestAttemptsMap) {
     const [problemHeaders, ...problemData] = problems;
     const problemObjs = convert2DArrayToObjects(problemHeaders, problemData);

--- a/src/Selection/ListSelection/ListSelectionLogic.js
+++ b/src/Selection/ListSelection/ListSelectionLogic.js
@@ -1,4 +1,4 @@
-const { NoMoreProblemsError } = require("../../errors");
+const { NoMoreProblemsError, ProblemNotFoundError } = require("../../errors");
 const { convert2DArrayToObjects } = require("../../utils/convert2DArrayToObjects");
 const { convertArrayToObject } = require("../../utils/convertArrayToObject");
 
@@ -7,7 +7,7 @@ function getFirstProblem(orderedList, problems) {
     const matches = filter2DArrayRows(problems, [{ field: 'name', value: problemName, mode: 'equals' }]);
 
     if (!matches.length) {
-        throw new Error(`Problem ${problemName} not found`);
+        throw new ProblemNotFoundError(`Problem ${problemName} not found`);
     }
     
     return convertArrayToObject(problems[0], matches[1]);
@@ -23,7 +23,7 @@ function getNextProblem(orderedList, problems, latestAttemptsMap) {
     for (let i = 1; i < orderedList.length; i++) {
         const name = orderedList[i][1];
         const problem = problemsMap[name];
-        if (!problem) throw new Error(`Problem ${name} not found`);
+        if (!problem) throw new ProblemNotFoundError(`Problem ${name} not found`);
 
         const latestAttempt = latestAttemptsMap[problem.lcId];
         

--- a/src/Selection/ListSelection/ListSelectionLogic.js
+++ b/src/Selection/ListSelection/ListSelectionLogic.js
@@ -1,0 +1,45 @@
+const { NoMoreProblemsError } = require("../../errors");
+const { convert2DArrayToObjects } = require("../../utils/convert2DArrayToObjects");
+const { convertArrayToObject } = require("../../utils/convertArrayToObject");
+
+function getFirstProblem(orderedList, problems) {
+    const problemName = orderedList[1][1];
+    const matches = filter2DArrayRows(problems, [{ field: 'name', value: problemName, mode: 'equals' }]);
+
+    if (!matches.length) {
+        throw new Error(`Problem ${problemName} not found`);
+    }
+    
+    return convertArrayToObject(problems[0], matches[1]);
+}
+
+function getNextProblem(orderedList, problems, latestAttemptsMap) {
+    const [problemHeaders, ...problemData] = problems;
+    const problemObjs = convert2DArrayToObjects(problemHeaders, problemData);
+    const problemsMap = Object.fromEntries(
+        problemObjs.map(problem => [problem.name, problem])
+    )
+
+    for (let i = 1; i < orderedList.length; i++) {
+        const name = orderedList[i][1];
+        const problem = problemsMap[orderedList[i][1]];
+        if (!problem) throw new Error(`Problem ${name} not found`);
+
+        const latestAttempt = latestAttemptsMap[problem.lcId];
+        
+        if (!latestAttempt) return problem;
+
+        if (i === 1) continue;
+
+        const prevOrderLatestAttempt = latestAttemptsMap[problemsMap[orderedList[i - 1][1]].lcId];
+
+        if (latestAttempt.startTime < prevOrderLatestAttempt.startTime) return problem;
+    }
+
+    throw new NoMoreProblemsError();
+}
+
+module.exports = {
+    getFirstProblem,
+    getNextProblem,
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,14 @@ const NAMED_RANGES = {
         ATTEMPTS: 'LatestAttempts_Attempts',
         COUNT: 'LatestAttempts_Count',
     },
+    ListSelection: {
+        LATEST_ATTEMPT_ATTRIBUTES: 'ListSelection_LatestAttemptAttributes',
+        LIST: 'ListSelection_List',
+        OPTIMAL_SOLUTION: 'ListSelection_OptimalSolution',
+        PROBLEM_ATTRIBUTES: 'ListSelection_ProblemAttributes',
+        PROBLEM_SEARCH_INPUTS: 'ListSelection_ProblemSearchInputs',
+        TIME_SINCE_CURRENT_PROBLEM: 'ListSelection_TimeSince',
+    },
     MetricsDashboard: {
         EXCLUDE_DOMINANT_TOPICS: 'MetricsDashboard_ExcludeDominantTopics',
         GROUP_KEYS: 'MetricsDashboard_GroupKeys',
@@ -103,6 +111,7 @@ const NAMED_RANGES = {
 
 const PROBLEM_SELECTORS = {
     GROUP_SELECTION: 'GroupSelection',
+    LIST_SELECTION: 'ListSelection',
     SINGLE_SELECTION: 'SingleSelection',
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,18 @@
+class ProblemNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'ProblemNotFoundError';
+    }
+}
+
+class NoMoreProblemsError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'NoMoreProblemsError';
+    }
+}
+
+module.exports = {
+    ProblemNotFoundError,
+    NoMoreProblemsError,
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,3 +1,6 @@
+/**
+ * Represents an error when a problem cannot be found in the dataset.
+ */
 class ProblemNotFoundError extends Error {
     constructor(message) {
         super(message);
@@ -5,6 +8,9 @@ class ProblemNotFoundError extends Error {
     }
 }
 
+/**
+ * Represents an error when all problems in a list have been attempted.
+ */
 class NoMoreProblemsError extends Error {
     constructor(message) {
         super(message);

--- a/src/logWorkflow.js
+++ b/src/logWorkflow.js
@@ -1,4 +1,6 @@
 const { NAMED_RANGES, SHEET_NAMES, PROBLEM_SELECTORS } = require("./constants");
+const { handleListSelection } = require("./Selection/ListSelection/ListSelectionHandlers");
+const { getNextProblem } = require("./Selection/ListSelection/ListSelectionLogic");
 const { getInputValues } = require("./sheetUtils/getInputValues");
 const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
 const { getSheetByName } = require("./sheetUtils/getSheetByName");
@@ -17,6 +19,7 @@ function onLogClick() {
     }
 
     logAttempt();
+    resetAttemptInputs();
 
     const attemptInitiator = getNamedRangeValue(NAMED_RANGES.AttemptInProgress.INITIATOR);
     if (attemptInitiator === PROBLEM_SELECTORS.GROUP_SELECTION) {
@@ -24,9 +27,10 @@ function onLogClick() {
     }
     else if (attemptInitiator === PROBLEM_SELECTORS.SINGLE_SELECTION) {
         clearCurrentProblem(PROBLEM_SELECTORS.SINGLE_SELECTION);
+    } else if (attemptInitiator === PROBLEM_SELECTORS.LIST_SELECTION) {
+        handleListSelection(getNextProblem);
     }
 
-    resetAttemptInputs();
     getSheetByName(attemptInitiator).activate();
     getSheetByName(SHEET_NAMES.ATTEMPT_IN_PROGRESS).hideSheet();
 }

--- a/src/skipWorkflow.js
+++ b/src/skipWorkflow.js
@@ -1,5 +1,6 @@
 const { NAMED_RANGES, PROBLEM_SELECTORS } = require("./constants");
 const { generateProblemSelectionList } = require("./dataModelUtils/generateProblemSelectionList");
+const { ProblemNotFoundError, NoMoreProblemsError } = require("./errors");
 const { getNamedRangeValue } = require("./sheetUtils/getNamedRangeValue");
 const { isAttemptInProgress, updateCurrentProblem, updateSkipCount } = require("./workflowUtils");
 
@@ -70,18 +71,4 @@ function findNextProblemIndex(problemsAttributes, currentLcId) {
     }
 
     return nextIndex;
-}
-
-class ProblemNotFoundError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = 'ProblemNotFoundError';
-    }
-}
-
-class NoMoreProblemsError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = 'NoMoreProblemsError';
-    }
 }

--- a/src/startWorkflow.js
+++ b/src/startWorkflow.js
@@ -31,6 +31,18 @@ function onSingleSelectionStartClick() {
 }
 
 /**
+ * Starts a problem attempt from the List Selection view.
+ *
+ * Retrieves the problem attributes from the List Selection control panel section  
+ * and initiates the attempt workflow.
+ *
+ * @returns {void}
+ */
+function onListSelectionStartClick() {
+    startWorkflow(NAMED_RANGES.ListSelection.PROBLEM_ATTRIBUTES, PROBLEM_SELECTORS.LIST_SELECTION);
+}
+
+/**
  * Starts a problem attempt workflow by verifying readiness and transitioning to the Attempt In Progress sheet.
  *
  * - Validates that no other attempt is already in progress.


### PR DESCRIPTION
### Related Issue
Closes #105 

### Problem
LeetLogger did not have a way to iterate through **ordered problem lists** (e.g., LeetCode 75 or curated company/problem sets).  
Existing views (GroupSelection and SingleSelection) either ignore list order or require manual selection per problem, making it inefficient to follow ranked lists.  
A new ListSelection mode was needed to automatically progress through a list, allow restarting from the first problem, and integrate with the attempt logging system.

---

### Changes
- **New ListSelection Handlers** (`src/Selection/ListSelection/ListSelectionHandlers.js`)  
  - `onNextClick` and `onRestartClick` Sheet-bound triggers.  
  - `handleListSelection(selectFn)` core function:
    - Checks `isAttemptInProgress()`.  
    - Clears the current problem selection.  
    - Retrieves and filters the selected list (`Skip = false`).  
    - Delegates to `getFirstProblem` or `getNextProblem`.  
    - Handles `ProblemNotFoundError` and `NoMoreProblemsError`.  
    - Updates current problem with merged latest attempt attributes.

- **Selection Logic** (`src/Selection/ListSelection/ListSelectionLogic.js`)  
  - `getFirstProblem(orderedList, problems)` — returns the first problem in a list; throws `ProblemNotFoundError` if missing.  
  - `getNextProblem(orderedList, problems, latestAttemptsMap)` — selects the next unattempted or less-recently-attempted problem based on list order; throws `NoMoreProblemsError` if all problems attempted.

- **Errors** (`src/errors.js`)  
  - Added `ProblemNotFoundError` and `NoMoreProblemsError` for consistent error handling across ListSelection.  
  - Removed redundant inline error definitions elsewhere.

- **Workflows & Constants**  
  - Added `ListSelection` constants to `NAMED_RANGES` and `PROBLEM_SELECTORS`.  
  - Updated `logWorkflow.js` to call `handleListSelection(getNextProblem)` after logging a ListSelection attempt.  
  - Added `onListSelectionStartClick()` in `startWorkflow.js` to initiate ListSelection attempts.

---

### Testing
- Verified `Restart` selects rank 1 problem.  
- Verified `Next` selects the next unattempted or appropriately ordered problem.  
- Confirmed alerts appear for missing problems (`ProblemNotFoundError`).  
- Confirmed restart prompt appears when all problems are attempted (`NoMoreProblemsError`).  
- Tested that rows with `Skip = true` are ignored.  
- Ensured `isAttemptInProgress()` prevents selection changes.  
- Confirmed integration with `logWorkflow` updates the selection panel correctly after attempts.

---

### Value
- Introduces the first implementation of **ListSelection** mode.  
- Enables users to progress through ordered problem lists efficiently.  
- Reduces manual effort and improves tracking for ranked or curated study lists.  
- Provides a maintainable separation between sheet-bound handlers and pure selection logic, paving the way for future enhancements (e.g., Dominant Pattern filtering).
